### PR TITLE
Reformat code using `gofumpt`

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -12,14 +12,14 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// shutdownTimeout is the duration that a graceful shutdown has to complete
+// shutdownTimeout is the duration within which a graceful shutdown has to complete.
 const shutdownTimeout = 5 * time.Second
 
 var log = logging.Logger("command/reference-provider")
 
 var (
 	ErrDaemonStart = errors.New("daemon did not start correctly")
-	ErrDaemonStop  = errors.New("daemon did not stop correctly")
+	ErrDaemonStop  = errors.New("daemon did not stop gracefully")
 )
 
 var DaemonCmd = &cli.Command{
@@ -34,7 +34,7 @@ func daemonCommand(cctx *cli.Context) error {
 	if err != nil {
 		if err == config.ErrNotInitialized {
 			fmt.Fprintln(os.Stderr, "reference provider is not initialized")
-			fmt.Fprintln(os.Stderr, "To initialize, run the command: ./indexer-reference-provider init")
+			fmt.Fprintln(os.Stderr, "To initialize, run the command: ./indexer-reference-provider init") // TODO adjust `./`; see how we can simplify the message here so that it would make sense regardless of OS or where the binary is located
 			os.Exit(1)
 		}
 		return fmt.Errorf("cannot load config file: %w", err)
@@ -42,8 +42,7 @@ func daemonCommand(cctx *cli.Context) error {
 
 	_ = cfg.Identity
 
-	// TODO: Create new libp2p host from identity, and
-	// intialize new provider engine
+	// TODO: Create new libp2p host from identity, and initialize new provider engine
 
 	log.Info("Starting daemon servers")
 	errChan := make(chan error, 3)

--- a/command/flags.go
+++ b/command/flags.go
@@ -8,6 +8,7 @@ import (
 var DaemonFlags = []cli.Flag{
 	phFlag,
 }
+
 var InitFlags = []cli.Flag{
 	phFlag,
 }

--- a/config/config.go
+++ b/config/config.go
@@ -19,7 +19,7 @@ const (
 	// DefaultPathName is the default config dir name
 	DefaultPathName = ".reference-provider"
 	// DefaultPathRoot is the path to the default config dir location.
-	DefaultPathRoot = "~/" + DefaultPathName
+	DefaultPathRoot = "~/" + DefaultPathName // TODO this won't work on windows. use user home dir instead
 	// DefaultConfigFile is the filename of the configuration file
 	DefaultConfigFile = "config"
 	// EnvDir is the environment variable used to change the path root.
@@ -101,7 +101,7 @@ func (c *Config) Save(filePath string) error {
 		}
 	}
 
-	err = os.MkdirAll(filepath.Dir(filePath), 0755)
+	err = os.MkdirAll(filepath.Dir(filePath), 0o755)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (c *Config) Save(filePath string) error {
 	return err
 }
 
-// String returns a pretty-printed json config
+// String returns a pretty-printed json config.
 func (c *Config) String() string {
 	b, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {

--- a/config/identity.go
+++ b/config/identity.go
@@ -18,7 +18,7 @@ type Identity struct {
 	PrivKey string `json:",omitempty"`
 }
 
-// DecodePrivateKey is a helper to decode the users PrivateKey
+// DecodePrivateKey is a helper to decode the user's PrivateKey.
 func (i *Identity) DecodePrivateKey(passphrase string) (ic.PrivKey, error) {
 	pkb, err := base64.StdEncoding.DecodeString(i.PrivKey)
 	if err != nil {

--- a/config/init.go
+++ b/config/init.go
@@ -34,12 +34,12 @@ func CreateIdentity(out io.Writer) (Identity, error) {
 	var sk crypto.PrivKey
 	var pk crypto.PubKey
 
-	fmt.Fprintf(out, "generating ED25519 keypair...")
+	fmt.Fprint(out, "generating ED25519 keypair...")
 	priv, pub, err := crypto.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		return ident, err
 	}
-	fmt.Fprintf(out, "done\n")
+	fmt.Fprintln(out, "done")
 
 	sk = priv
 	pk = pub

--- a/core/engine/engine.go
+++ b/core/engine/engine.go
@@ -39,8 +39,7 @@ type Engine struct {
 	pubSubTopic string
 }
 
-// New creates a reference provider engine with the corresponding
-// config
+// New creates a reference provider engine with the corresponding config.
 func New(ctx context.Context, host host.Host, ds datastore.Batching, index indexer.Interface, pubSubTopic string) (*Engine, error) {
 	log.Debugw("Starting new reference provider engine")
 	lsys := mkLinkSystem(ds)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,8 @@ var GitVersion string = "unknown"
 
 var reVersion = regexp.MustCompile(`^(v\d+\.\d+.\d+)(?:-)?(.+)?$`)
 
-// String formats the version in semver format, see semver.org
+// String formats the version in semver format.
+// See: semver.org
 func String() string {
 	matches := reVersion.FindStringSubmatch(GitVersion)
 	if matches == nil || len(matches) < 3 {

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -21,5 +21,4 @@ func TestString(t *testing.T) {
 		}
 
 	}
-
 }

--- a/main.go
+++ b/main.go
@@ -28,10 +28,10 @@ func main() {
 		case <-interrupt:
 			cancel()
 			fmt.Println("Received interrupt signal, shutting down...")
-			fmt.Println("(Hit ctrl-c again to force-shutdown the daemon.)")
+			fmt.Println("(Hit CTRL-C again to force-shutdown the daemon.)")
 		case <-ctx.Done():
 		}
-		// Allow any forther SIGTERM or SIGING to kill process
+		// Allow any further SIGTERM or SIGING to kill the process
 		signal.Stop(interrupt)
 	}()
 


### PR DESCRIPTION
Reformat the entire repo using `gofumpt -l -w` for consistency going forward.

Refactor small utility functions for better readability.

Update docs and leave TODOs where needed.