### PR TITLE
Register CAR supplier in daemon engine

### DIFF
--- a/command/flags.go
+++ b/command/flags.go
@@ -4,13 +4,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var DaemonFlags = []cli.Flag{
-	phFlag,
+var daemonFlags = []cli.Flag{
+	carZeroLengthAsEOFFlag,
 }
 
-var InitFlags = []cli.Flag{
-	phFlag,
-}
+var initFlags = []cli.Flag{}
 
 var connectFlags = []cli.Flag{
 	&cli.StringFlag{
@@ -29,10 +27,13 @@ var adminAPIFlag = &cli.StringFlag{
 	Required: false,
 }
 
-var phFlag = &cli.BoolFlag{
-	Name:     "placeholder",
-	Usage:    "Placeholder Flag to run provider",
-	Aliases:  []string{"ph"},
-	Value:    false,
-	Required: false,
-}
+var (
+	carZeroLengthAsEOF     bool
+	carZeroLengthAsEOFFlag = &cli.BoolFlag{
+		Name:        "carZeroLengthAsEOF",
+		Aliases:     []string{"cz"},
+		Usage:       "Specifies whether zero-length blocks in CAR should be consideted as EOF.",
+		Value:       false, // Default to disabled, consistent with go-car/v2 defaults.
+		Destination: &carZeroLengthAsEOF,
+	}
+)

--- a/command/init.go
+++ b/command/init.go
@@ -10,7 +10,7 @@ import (
 var InitCmd = &cli.Command{
 	Name:   "init",
 	Usage:  "Initialize reference provider config file and identity",
-	Flags:  InitFlags,
+	Flags:  initFlags,
 	Action: initCommand,
 }
 

--- a/core/engine/engine_test.go
+++ b/core/engine/engine_test.go
@@ -79,7 +79,6 @@ func mkEngine(t *testing.T) (*Engine, error) {
 	store := dssync.MutexWrap(datastore.NewMapDatastore())
 
 	return New(context.Background(), priv, h, store, testTopic)
-
 }
 
 func connectHosts(t *testing.T, srcHost, dstHost host.Host) {
@@ -288,7 +287,6 @@ func TestNotifyPutWithCallback(t *testing.T) {
 			t.Fatalf("not the right advertisement published %s vs %s", downstream, c)
 		}
 	}
-
 }
 
 func clean(ls legs.LegSubscriber, lt *legs.LegTransport, e *Engine, cncl context.CancelFunc) func() {

--- a/internal/suppliers/callback.go
+++ b/internal/suppliers/callback.go
@@ -1,0 +1,34 @@
+package suppliers
+
+import (
+	"io"
+
+	"github.com/filecoin-project/indexer-reference-provider/core"
+	"github.com/ipfs/go-cid"
+)
+
+// ToCidCallback converts the given cidIter to core.CidCallback.
+func ToCidCallback(cidIterSup CidIteratorSupplier) core.CidCallback {
+	return func(key cid.Cid) ([]cid.Cid, error) {
+		ci, err := cidIterSup.Supply(key)
+		if err != nil {
+			return nil, err
+		}
+		return drain(ci)
+	}
+}
+
+func drain(ci CidIterator) ([]cid.Cid, error) {
+	cidList := make([]cid.Cid, 0)
+	for {
+		c, err := ci.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		cidList = append(cidList, c)
+	}
+	return cidList, nil
+}

--- a/internal/suppliers/callback_test.go
+++ b/internal/suppliers/callback_test.go
@@ -1,0 +1,66 @@
+package suppliers
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-car/v2/blockstore"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_drain(t *testing.T) {
+	tests := []struct {
+		name    string
+		carPath string
+	}{
+		{
+			"CARv1ReturnsExpectedCIDs",
+			"../../testdata/sample-v1.car",
+		},
+		{
+			"CARv2ReturnsExpectedCIDs",
+			"../../testdata/sample-wrapped-v2.car",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cidIter, err := newCarCidIterator(tt.carPath)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, cidIter.Close()) })
+
+			// Open ReadOnly blockstore used to provide wanted case for testing
+			want, err := blockstore.OpenReadOnly(tt.carPath)
+			require.NoError(t, err)
+
+			// Wait at most 3 seconds for iteration over wanted CIDs.
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+
+			// Fail immediately if error is encountered while iterating over CIDs.
+			ctx = blockstore.WithAsyncErrorHandler(ctx, func(err error) { require.Fail(t, "expected no error", "%v", err) })
+			t.Cleanup(cancel)
+
+			// Instantiate wanted CIDs channel
+			keysChan, err := want.AllKeysChan(ctx)
+			require.NoError(t, err)
+
+			gotCids, err := drain(cidIter)
+			require.NoError(t, err)
+
+			// Assert CIDs are consistent with the drained iterator
+			var i int
+			for wantCid := range keysChan {
+				gotCid := gotCids[i]
+				require.Equal(t, wantCid, gotCid)
+				i++
+			}
+
+			// Assert drain has fully drained the iterator
+			gotCid, gotErr := cidIter.Next()
+			require.Equal(t, io.EOF, gotErr)
+			require.Equal(t, cid.Undef, gotCid)
+		})
+	}
+}

--- a/internal/suppliers/car_supplier.go
+++ b/internal/suppliers/car_supplier.go
@@ -13,7 +13,11 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
-const carPathKeyPrefix = "car://"
+const (
+	carSupplierDatastorePrefix = "car_supplier://"
+	carPathDatastoreKeyPrefix  = carSupplierDatastorePrefix + "car_path/"
+	carIdDatastoreKeyPrefix    = carSupplierDatastorePrefix + "car_id/"
+)
 
 var (
 	_ CidIteratorSupplier = (*CarSupplier)(nil)
@@ -74,7 +78,7 @@ func (cs *CarSupplier) PutWithID(id cid.Cid, path string) (cid.Cid, error) {
 }
 
 func toCarIdKey(id cid.Cid) datastore.Key {
-	return datastore.NewKey(id.String())
+	return datastore.NewKey(carIdDatastoreKeyPrefix + id.String())
 }
 
 // Remove removes the CAR at the given path from the list of suppliable CID iterators.
@@ -183,5 +187,5 @@ func toPathKey(path string) datastore.Key {
 	encPathHash := base64.StdEncoding.EncodeToString(pathHash)
 
 	// Prefix the hash with some constant for namespacing and debug readability.
-	return datastore.NewKey(carPathKeyPrefix + encPathHash)
+	return datastore.NewKey(carPathDatastoreKeyPrefix + encPathHash)
 }


### PR DESCRIPTION
Instantiate a CAR supplier that uses the same underlying datastore as
the engine, convert it to `CidCallback` and register it. Define a new
flag for daemon that allows configuration of CAR read option on how to
treat zero-length blocks.

Adjust the prefix of datastore entries produced by CAR supplier to avoid
clash since datastore is shared with engine and the supplier.

Add utility to convert a streaming CID supplier to the non-streaming
`CidCallback`. Note, we want to retain the streaming abilities
implemented already for future use, e.g. chunking of CID list etc.

Write tests that assert draining a streaming CID iterator is correct.

Unexport flags until they need to be exported and remove placeholders.