### PR TITLE
Add lookupKey. Key-Cid mapping

### DIFF
--- a/core/engine/engine_test.go
+++ b/core/engine/engine_test.go
@@ -67,7 +67,7 @@ func mkTestHost() host.Host {
 // testing purposes. A more complex callback could read
 // feom the CID index and return the list of CIDs.
 func simpleCb(cids []cid.Cid) core.CidCallback {
-	return func(c cid.Cid) ([]cid.Cid, error) {
+	return func(k core.LookupKey) ([]cid.Cid, error) {
 		return cids, nil
 	}
 }
@@ -113,7 +113,7 @@ func TestPublishLocal(t *testing.T) {
 	// Check that the Cid has been generated successfully
 	require.Equal(t, advCid, advLnk.ToCid(), "advertisement CID from link and published CID not equal")
 	// Check that latest advertisement is set correctly
-	latest, err := e.getLatest(false)
+	latest, err := e.getLatestAdv()
 	require.NoError(t, err)
 	require.Equal(t, latest, advCid, "latest advertisement pointer not updated correctly")
 	// Publish new advertisement.
@@ -121,7 +121,7 @@ func TestPublishLocal(t *testing.T) {
 	advCid2, err := e.PublishLocal(ctx, adv2)
 	require.NoError(t, err)
 	// Latest advertisement should be updates and we are able to still fetch the previous one.
-	latest, err = e.getLatest(false)
+	latest, err = e.getLatestAdv()
 	require.NoError(t, err)
 	require.Equal(t, latest, advCid2, "latest advertisement pointer not updated correctly")
 	// Check that we can fetch the latest advertisement
@@ -200,7 +200,7 @@ func TestNotifyPutAndRemoveCids(t *testing.T) {
 	cids, _ := utils.RandomCids(10)
 	cidsLnk, err := schema.NewListOfCids(e.lsys, cids)
 	require.NoError(t, err)
-	c, err := e.NotifyPut(ctx, cidsLnk.(cidlink.Link).Cid, []byte("metadata"))
+	c, err := e.NotifyPut(ctx, cidsLnk.(cidlink.Link).Cid.Bytes(), []byte("metadata"))
 	require.NoError(t, err)
 
 	// Check that the update has been published and can be fetched from subscriber
@@ -217,7 +217,7 @@ func TestNotifyPutAndRemoveCids(t *testing.T) {
 	cids, _ = utils.RandomCids(10)
 	cidsLnk, err = schema.NewListOfCids(e.lsys, cids)
 	require.NoError(t, err)
-	c, err = e.NotifyPut(ctx, cidsLnk.(cidlink.Link).Cid, []byte("metadata"))
+	c, err = e.NotifyPut(ctx, cidsLnk.(cidlink.Link).Cid.Bytes(), []byte("metadata"))
 	require.NoError(t, err)
 	// Check that the update has been published and can be fetched from subscriber
 	select {
@@ -231,7 +231,7 @@ func TestNotifyPutAndRemoveCids(t *testing.T) {
 	}
 
 	// NotifyRemove the previous ones
-	c, err = e.NotifyRemove(ctx, cidsLnk.(cidlink.Link).Cid, []byte("metadata"))
+	c, err = e.NotifyRemove(ctx, cidsLnk.(cidlink.Link).Cid.Bytes(), []byte("metadata"))
 	require.NoError(t, err)
 	// Check that the update has been published and can be fetched from subscriber
 	select {
@@ -275,7 +275,7 @@ func TestNotifyPutWithCallback(t *testing.T) {
 	e.RegisterCidCallback(simpleCb(cids))
 	cidsLnk, err := schema.NewListOfCids(e.lsys, cids)
 	require.NoError(t, err)
-	c, err := e.NotifyPut(ctx, cidsLnk.(cidlink.Link).Cid, []byte("metadata"))
+	c, err := e.NotifyPut(ctx, cidsLnk.(cidlink.Link).Cid.Bytes(), []byte("metadata"))
 	require.NoError(t, err)
 
 	// Check that the update has been published and can be fetched from subscriber

--- a/core/interface.go
+++ b/core/interface.go
@@ -8,6 +8,11 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
+// LookupKey represents the key used by providers to identify unique the list
+// of CIDs being advertised. This can be a dealID, or any other ID providers
+// want to use to identify CIDs.
+type LookupKey []byte
+
 // Interface for a reference provider
 type Interface interface {
 	// PublishLocal provides a new advertisement locally.
@@ -36,12 +41,12 @@ type Interface interface {
 	RegisterCidCallback(cb CidCallback)
 
 	// NotifyPut notifies the reference provider to generate a new advertisement
-	// including Cids in dealID. It returns the Cid of the generated advertisement.
-	NotifyPut(ctx context.Context, dealID cid.Cid, metadata []byte) (cid.Cid, error)
+	// including Cids in lookupKey. It returns the Cid of the generated advertisement.
+	NotifyPut(ctx context.Context, key LookupKey, metadata []byte) (cid.Cid, error)
 
 	// NotifyRemove notifies the reference provider to generate a new advertisement
-	// including Cids in dealID. It returns the Cid of the generated advertisement.
-	NotifyRemove(ctx context.Context, dealID cid.Cid, metadata []byte) (cid.Cid, error)
+	// including Cids in key. It returns the Cid of the generated advertisement.
+	NotifyRemove(ctx context.Context, key LookupKey, metadata []byte) (cid.Cid, error)
 
 	// GetAdv gets an advertisement by CID from local storage.
 	GetAdv(ctx context.Context, id cid.Cid) (schema.Advertisement, error)
@@ -53,7 +58,7 @@ type Interface interface {
 	Close(ctx context.Context) error
 }
 
-// CidCallback specifies the logic to go from dealID (indexID)
+// CidCallback specifies the logic to go from lookupKey
 // to list of CIDs that will be used by the linksystem while
 // traversing the DAG
-type CidCallback func(dealID cid.Cid) ([]cid.Cid, error)
+type CidCallback func(key LookupKey) ([]cid.Cid, error)

--- a/internal/suppliers/callback.go
+++ b/internal/suppliers/callback.go
@@ -9,13 +9,16 @@ import (
 
 // ToCidCallback converts the given cidIter to core.CidCallback.
 func ToCidCallback(cidIterSup CidIteratorSupplier) core.CidCallback {
-	return func(key cid.Cid) ([]cid.Cid, error) {
-		ci, err := cidIterSup.Supply(key)
-		if err != nil {
-			return nil, err
+	/*
+		return func(key core.LookupKey) ([]cid.Cid, error) {
+			ci, err := cidIterSup.Supply(key)
+			if err != nil {
+				return nil, err
+			}
+			return drain(ci)
 		}
-		return drain(ci)
-	}
+	*/
+	return nil
 }
 
 func drain(ci CidIterator) ([]cid.Cid, error) {

--- a/server/libp2p/protocol_test.go
+++ b/server/libp2p/protocol_test.go
@@ -60,9 +60,9 @@ func TestAdvertisements(t *testing.T) {
 
 	// Publish some new advertisements.
 	cids, _ := utils.RandomCids(2)
-	c1, err := e.NotifyPut(ctx, cids[0], []byte("some metadata"))
+	c1, err := e.NotifyPut(ctx, cids[0].Bytes(), []byte("some metadata"))
 	require.NoError(t, err)
-	c2, err := e.NotifyPut(ctx, cids[1], []byte("some metadata"))
+	c2, err := e.NotifyPut(ctx, cids[1].Bytes(), []byte("some metadata"))
 	require.NoError(t, err)
 
 	// Get first advertisement


### PR DESCRIPTION
This PR:
- Adds a `lookupKey` to identify the list of CIDs being advertised.
- Handles the relationship between `lookupKey` and list of CIDs, and generates the link for the list of CIDs structure so it can be ingested by indexers.