### PR TITLE
Implement admin server handler for importing CAR files

### DIFF
--- a/server/http/importcar_handler.go
+++ b/server/http/importcar_handler.go
@@ -1,0 +1,58 @@
+package adminserver
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/filecoin-project/indexer-reference-provider/core"
+	"github.com/filecoin-project/indexer-reference-provider/internal/suppliers"
+	"github.com/ipfs/go-cid"
+)
+
+type importCarHandler struct {
+	cs *suppliers.CarSupplier
+}
+
+func (h *importCarHandler) handle(w http.ResponseWriter, r *http.Request) {
+	var req ImportCarReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		log.Errorw("cannot unmarshal request", "err", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	var key core.LookupKey
+	var advId cid.Cid
+	var err error
+	ctx := context.Background()
+	if req.hasId() {
+		key = req.Key
+		advId, err = h.cs.PutWithID(ctx, req.Key, req.Path, req.Metadata)
+	} else {
+		key, advId, err = h.cs.Put(ctx, req.Path, req.Metadata)
+	}
+
+	if err != nil {
+		log.Errorw("failed to put CAR", "err", err, "path", req.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	resp := &ImportCarRes{key, advId}
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		log.Errorw("failed to serialized response for imported CAR", "err", err)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	if _, err = w.Write(respBytes); err != nil {
+		log.Errorw("failed to write response body", "err", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (req *ImportCarReq) hasId() bool {
+	return len(req.Key) != 0
+}

--- a/server/http/importcar_handler_test.go
+++ b/server/http/importcar_handler_test.go
@@ -1,0 +1,66 @@
+package adminserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mock_core "github.com/filecoin-project/indexer-reference-provider/core/mock"
+	"github.com/filecoin-project/indexer-reference-provider/internal/suppliers"
+	"github.com/filecoin-project/indexer-reference-provider/internal/utils"
+	"github.com/golang/mock/gomock"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_importCarHandler(t *testing.T) {
+	wantKey := []byte("lobster")
+	wantMetadata := []byte("munch")
+	icReq := &ImportCarReq{
+		Path:     "fish",
+		Key:      wantKey,
+		Metadata: wantMetadata,
+	}
+
+	jsonReq, err := json.Marshal(icReq)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "/admin/import/car", bytes.NewReader(jsonReq))
+	require.NoError(t, err)
+
+	mc := gomock.NewController(t)
+	mockEng := mock_core.NewMockInterface(mc)
+	mockEng.EXPECT().RegisterCidCallback(gomock.Any())
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	cs := suppliers.NewCarSupplier(mockEng, ds)
+
+	subject := importCarHandler{cs}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(subject.handle)
+	randCids, err := utils.RandomCids(1)
+	require.NoError(t, err)
+	wantCid := randCids[0]
+
+	mockEng.
+		EXPECT().
+		NotifyPut(gomock.Any(), gomock.Eq(wantKey), gomock.Eq(wantMetadata)).
+		Return(wantCid, nil)
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	respBytes, err := ioutil.ReadAll(rr.Body)
+	require.NoError(t, err)
+
+	var resp ImportCarRes
+	err = json.Unmarshal(respBytes, &resp)
+	require.NoError(t, err)
+	require.Equal(t, wantKey, resp.Key)
+	require.Equal(t, wantCid, resp.AdvId)
+}

--- a/server/http/models.go
+++ b/server/http/models.go
@@ -1,6 +1,26 @@
 package adminserver
 
+import "github.com/ipfs/go-cid"
+
 // ConnectReq request
 type ConnectReq struct {
 	Maddr string
+}
+
+// ImportCarReq represents a request for importing a CAR file.
+type ImportCarReq struct {
+	// The path to the CAR file
+	Path string `json:"path"`
+	// The optional lookup key associated to the CAR. If not provided, one will be generated.
+	Key []byte `json:"key"`
+	// The optional metadata.
+	Metadata []byte `json:"metadata"`
+}
+
+// ImportCarRes represents the response to an ImportCarReq.
+type ImportCarRes struct {
+	// The lookup Key associated to the imported CAR.
+	Key []byte `json:"key"`
+	// The CID of the advertisement generated as a result of import.
+	AdvId cid.Cid `json:"adv_id"`
 }

--- a/server/http/server.go
+++ b/server/http/server.go
@@ -20,7 +20,6 @@ type Server struct {
 	l      net.Listener
 	h      host.Host
 	e      *engine.Engine
-	cs     *suppliers.CarSupplier // TODO Placeholder to implement `import` command
 }
 
 func New(listen string, h host.Host, e *engine.Engine, cs *suppliers.CarSupplier, options ...ServerOption) (*Server, error) {
@@ -41,10 +40,12 @@ func New(listen string, h host.Host, e *engine.Engine, cs *suppliers.CarSupplier
 		WriteTimeout: cfg.apiWriteTimeout,
 		ReadTimeout:  cfg.apiReadTimeout,
 	}
-	s := &Server{server, l, h, e, cs}
+	s := &Server{server, l, h, e}
 
 	// Set protocol handlers
 	r.HandleFunc("/admin/connect", s.connectHandler).Methods("POST")
+	icHandler := &importCarHandler{cs}
+	r.HandleFunc("/admin/import/car", icHandler.handle).Methods("POST")
 
 	return s, nil
 }


### PR DESCRIPTION
Implement handler for POST requests to `admin/import/car` endpoint to
request import of a CAR file from a given path with optional key and
metadata.