### PR TITLE
Implement `import car` CLI command

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -99,7 +99,7 @@ func daemonCommand(cctx *cli.Context) error {
 	}
 
 	// Instantiate CAR supplier and register it as a callback onto the engine.
-	cs := suppliers.NewCarSupplier(eng, ds, car.ZeroLengthSectionAsEOF(carZeroLengthAsEOF))
+	cs := suppliers.NewCarSupplier(eng, ds, car.ZeroLengthSectionAsEOF(carZeroLengthAsEOFFlagValue))
 
 	// Starting provider p2p server
 	p2pserver.New(ctx, h, eng)

--- a/command/flags.go
+++ b/command/flags.go
@@ -20,20 +20,64 @@ var connectFlags = []cli.Flag{
 	adminAPIFlag,
 }
 
-var adminAPIFlag = &cli.StringFlag{
-	Name:     "listen-admin",
-	Usage:    "Admin HTTP API listen address",
-	EnvVars:  []string{"PROVIDER_LISTEN_ADMIN"},
-	Required: false,
+var importCarFlags = []cli.Flag{
+	adminAPIFlag,
+	carPathFlag,
+	metadataFlag,
+	keyFlag,
 }
 
 var (
-	carZeroLengthAsEOF     bool
-	carZeroLengthAsEOFFlag = &cli.BoolFlag{
+	metadataFlagValue string
+	metadataFlag      = &cli.StringFlag{
+		Name:        "metadata",
+		Usage:       "Base64 encoded metadata bytes.",
+		Aliases:     []string{"m"},
+		Required:    false,
+		Destination: &metadataFlagValue,
+	}
+)
+
+var (
+	keyFlagValue string
+	keyFlag      = &cli.StringFlag{
+		Name:        "key",
+		Usage:       "Base64 encoded lookup key to associate with imported CAR.",
+		Aliases:     []string{"k"},
+		Required:    false,
+		Destination: &keyFlagValue,
+	}
+)
+
+var (
+	carPathFlagValue string
+	carPathFlag      = &cli.StringFlag{
+		Name:        "input",
+		Aliases:     []string{"i"},
+		Usage:       "Path to the CAR file to import",
+		Destination: &carPathFlagValue,
+		Required:    true,
+	}
+)
+
+var (
+	adminAPIFlagValue string
+	adminAPIFlag      = &cli.StringFlag{
+		Name:        "listen-admin",
+		Usage:       "Admin HTTP API listen address",
+		EnvVars:     []string{"PROVIDER_LISTEN_ADMIN"},
+		Destination: &adminAPIFlagValue,
+		Required:    true,
+	}
+)
+
+var (
+	carZeroLengthAsEOFFlagValue bool
+	carZeroLengthAsEOFFlag      = &cli.BoolFlag{
 		Name:        "carZeroLengthAsEOF",
 		Aliases:     []string{"cz"},
 		Usage:       "Specifies whether zero-length blocks in CAR should be consideted as EOF.",
 		Value:       false, // Default to disabled, consistent with go-car/v2 defaults.
-		Destination: &carZeroLengthAsEOF,
+		Destination: &carZeroLengthAsEOFFlagValue,
 	}
 )

--- a/command/import.go
+++ b/command/import.go
@@ -1,0 +1,98 @@
+package command
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	adminserver "github.com/filecoin-project/indexer-reference-provider/server/http"
+	"github.com/urfave/cli/v2"
+)
+
+var ImportCmd = &cli.Command{
+	Name:        "import",
+	Aliases:     []string{"i"},
+	Usage:       "Imp",
+	Subcommands: []*cli.Command{importCarSubCmd},
+}
+
+var (
+	metadata        []byte
+	key             []byte
+	importCarSubCmd = &cli.Command{
+		Name:    "car",
+		Aliases: []string{"c"},
+		Usage:   "Imports CAR from a path",
+		Flags:   importCarFlags,
+		Before:  beforeImportCar,
+		Action:  doImportCar,
+	}
+)
+
+func beforeImportCar(context *cli.Context) error {
+	if metadataFlagValue != "" {
+		decoded, err := base64.StdEncoding.DecodeString(metadataFlagValue)
+		if err != nil {
+			return err
+		}
+		metadata = decoded
+	}
+	if keyFlagValue != "" {
+		decoded, err := base64.StdEncoding.DecodeString(keyFlagValue)
+		if err != nil {
+			return err
+		}
+		key = decoded
+	}
+	return nil
+}
+
+func doImportCar(cctx *cli.Context) error {
+	req := adminserver.ImportCarReq{
+		Path:     carPathFlagValue,
+		Key:      key,
+		Metadata: metadata,
+	}
+
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	bodyReader := bytes.NewReader(reqBody)
+	httpReq, err := http.NewRequestWithContext(cctx.Context, http.MethodPost, adminAPIFlagValue+"/admin/import/car", bodyReader)
+	if err != nil {
+		return err
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	cl := &http.Client{}
+	resp, err := cl.Do(httpReq)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to import car, due to failure response from Admin server: %v", http.StatusText(resp.StatusCode))
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var icRes adminserver.ImportCarRes
+	if err := json.Unmarshal(respBody, &icRes); err != nil {
+		return err
+	}
+
+	log.Infof("Successfully imported car")
+
+	msg := fmt.Sprintf("Successfully imported CAR.\n"+
+		"\t Advertisement ID: %v\n", icRes.AdvId)
+
+	_, err = cctx.App.Writer.Write([]byte(msg))
+	return err
+}

--- a/command/net.go
+++ b/command/net.go
@@ -25,7 +25,7 @@ func connectCommand(cctx *cli.Context) error {
 		return err
 	}
 	reqURL := adminaddr + "/admin/connect"
-	req, err := http.NewRequestWithContext(cctx.Context, "POST", reqURL, bytes.NewBuffer(data))
+	req, err := http.NewRequestWithContext(cctx.Context, http.MethodPost, reqURL, bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 			command.DaemonCmd,
 			command.InitCmd,
 			command.ConnectCmd,
+			command.ImportCmd,
 		},
 	}
 

--- a/server/http/importcar_handler_test.go
+++ b/server/http/importcar_handler_test.go
@@ -29,7 +29,7 @@ func Test_importCarHandler(t *testing.T) {
 	jsonReq, err := json.Marshal(icReq)
 	require.NoError(t, err)
 
-	req, err := http.NewRequest("POST", "/admin/import/car", bytes.NewReader(jsonReq))
+	req, err := http.NewRequest(http.MethodPost, "/admin/import/car", bytes.NewReader(jsonReq))
 	require.NoError(t, err)
 
 	mc := gomock.NewController(t)

--- a/server/http/server.go
+++ b/server/http/server.go
@@ -43,9 +43,9 @@ func New(listen string, h host.Host, e *engine.Engine, cs *suppliers.CarSupplier
 	s := &Server{server, l, h, e}
 
 	// Set protocol handlers
-	r.HandleFunc("/admin/connect", s.connectHandler).Methods("POST")
+	r.HandleFunc("/admin/connect", s.connectHandler).Methods(http.MethodPost)
 	icHandler := &importCarHandler{cs}
-	r.HandleFunc("/admin/import/car", icHandler.handle).Methods("POST")
+	r.HandleFunc("/admin/import/car", icHandler.handle).Methods(http.MethodPost)
 
 	return s, nil
 }


### PR DESCRIPTION
Implement `import car` command that takes a path and optional lookup
key and metadata, then connects to the admin HTTP API to import it.