### PR TITLE
Improve error handing in admin server

### DIFF
--- a/server/http/error.go
+++ b/server/http/error.go
@@ -1,0 +1,26 @@
+package adminserver
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// errResponseFailedToMarshalAsJson captures a fallback payload set in package init
+// to assure there is always a valid error response to return should all else fails.
+var errResponseFailedToMarshalAsJson []byte
+
+func init() {
+	// Assure there is always a marshalled response error should all things fail.
+	var err error
+	errFailedToMarshal := &ErrorRes{"failed to marshal response as JSON."}
+	errResponseFailedToMarshalAsJson, err = json.Marshal(errFailedToMarshal)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func newErrorResponse(format string, args ...interface{}) *ErrorRes {
+	return &ErrorRes{
+		Message: fmt.Sprintf(format, args...),
+	}
+}

--- a/server/http/io.go
+++ b/server/http/io.go
@@ -1,0 +1,97 @@
+package adminserver
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+var (
+	_ io.ReaderFrom = (*ErrorRes)(nil)
+	_ io.ReaderFrom = (*ImportCarReq)(nil)
+	_ io.ReaderFrom = (*ImportCarRes)(nil)
+	_ io.ReaderFrom = (*ConnectReq)(nil)
+	_ io.ReaderFrom = (*ConnectRes)(nil)
+
+	_ io.WriterTo = (*ErrorRes)(nil)
+	_ io.WriterTo = (*ImportCarReq)(nil)
+	_ io.WriterTo = (*ImportCarRes)(nil)
+	_ io.WriterTo = (*ConnectReq)(nil)
+	_ io.WriterTo = (*ConnectRes)(nil)
+)
+
+func (er *ErrorRes) WriteTo(w io.Writer) (int64, error) {
+	return marshalToJson(w, er)
+}
+
+func (er *ErrorRes) ReadFrom(r io.Reader) (int64, error) {
+	return unmarshalAsJson(r, er)
+}
+
+func (er *ImportCarReq) WriteTo(w io.Writer) (int64, error) {
+	return marshalToJson(w, er)
+}
+
+func (er *ImportCarReq) ReadFrom(r io.Reader) (int64, error) {
+	return unmarshalAsJson(r, er)
+}
+
+func (er *ImportCarRes) WriteTo(w io.Writer) (int64, error) {
+	return marshalToJson(w, er)
+}
+
+func (er *ImportCarRes) ReadFrom(r io.Reader) (int64, error) {
+	return unmarshalAsJson(r, er)
+}
+
+func (er *ConnectReq) WriteTo(w io.Writer) (int64, error) {
+	return marshalToJson(w, er)
+}
+
+func (er *ConnectReq) ReadFrom(r io.Reader) (int64, error) {
+	return unmarshalAsJson(r, er)
+}
+
+func (er *ConnectRes) WriteTo(w io.Writer) (int64, error) {
+	return marshalToJson(w, er)
+}
+
+func (er *ConnectRes) ReadFrom(r io.Reader) (int64, error) {
+	return unmarshalAsJson(r, er)
+}
+
+func respond(w http.ResponseWriter, statusCode int, body io.WriterTo) {
+	// Attempt to serialize body as JSON
+	if _, err := body.WriteTo(w); err != nil {
+		log.Errorw("faild to write response ", "err", err)
+		w.WriteHeader(http.StatusInternalServerError)
+
+		// Attemt to write fallback error response as body.
+		if _, err := w.Write(errResponseFailedToMarshalAsJson); err != nil {
+			// Nothing we can do; log and move on.
+			log.Errorw("faild to write fallback error response", "err", err)
+		}
+		return
+	}
+
+	// Write requested status code now that body is successfully written.
+	w.WriteHeader(statusCode)
+}
+
+func unmarshalAsJson(r io.Reader, dst interface{}) (int64, error) {
+	body, err := ioutil.ReadAll(r)
+	if err != nil {
+		return 0, err
+	}
+	return int64(len(body)), json.Unmarshal(body, dst)
+}
+
+func marshalToJson(w io.Writer, src interface{}) (int64, error) {
+	body, err := json.Marshal(src)
+	if err != nil {
+		return 0, err
+	}
+	written, err := w.Write(body)
+	return int64(written), err
+}

--- a/server/http/models.go
+++ b/server/http/models.go
@@ -2,25 +2,38 @@ package adminserver
 
 import "github.com/ipfs/go-cid"
 
-// ConnectReq request
-type ConnectReq struct {
-	Maddr string
+// ErrorRes represents a response that captures information about failure to handle a request.
+type ErrorRes struct {
+	// The human-readable message that provides hints about the failure cause.
+	Message string `json:"message"`
 }
 
-// ImportCarReq represents a request for importing a CAR file.
-type ImportCarReq struct {
-	// The path to the CAR file
-	Path string `json:"path"`
-	// The optional lookup key associated to the CAR. If not provided, one will be generated.
-	Key []byte `json:"key"`
-	// The optional metadata.
-	Metadata []byte `json:"metadata"`
-}
+type (
+	// ConnectReq request to connect to a given multiaddr.
+	ConnectReq struct {
+		Maddr string `json:"maddr"`
+	}
+	// ConnectRes represents successful response to ConnectReq request.
+	ConnectRes struct {
+		// Empty placeholder used to return an empty JSON object in body.
+	}
+)
 
-// ImportCarRes represents the response to an ImportCarReq.
-type ImportCarRes struct {
-	// The lookup Key associated to the imported CAR.
-	Key []byte `json:"key"`
-	// The CID of the advertisement generated as a result of import.
-	AdvId cid.Cid `json:"adv_id"`
-}
+type (
+	// ImportCarReq represents a request for importing a CAR file.
+	ImportCarReq struct {
+		// The path to the CAR file
+		Path string `json:"path"`
+		// The optional lookup key associated to the CAR. If not provided, one will be generated.
+		Key []byte `json:"key"`
+		// The optional metadata.
+		Metadata []byte `json:"metadata"`
+	}
+	// ImportCarRes represents the response to an ImportCarReq.
+	ImportCarRes struct {
+		// The lookup Key associated to the imported CAR.
+		Key []byte `json:"key"`
+		// The CID of the advertisement generated as a result of import.
+		AdvId cid.Cid `json:"adv_id"`
+	}
+)

--- a/server/http/server.go
+++ b/server/http/server.go
@@ -43,9 +43,14 @@ func New(listen string, h host.Host, e *engine.Engine, cs *suppliers.CarSupplier
 	s := &Server{server, l, h, e}
 
 	// Set protocol handlers
-	r.HandleFunc("/admin/connect", s.connectHandler).Methods(http.MethodPost)
+	r.HandleFunc("/admin/connect", s.connectHandler).
+		Methods(http.MethodPost).
+		Headers("Content-Type", "application/json")
+
 	icHandler := &importCarHandler{cs}
-	r.HandleFunc("/admin/import/car", icHandler.handle).Methods(http.MethodPost)
+	r.HandleFunc("/admin/import/car", icHandler.handle).
+		Methods(http.MethodPost).
+		Headers("Content-Type", "application/json")
 
 	return s, nil
 }


### PR DESCRIPTION
Define a dedicated error response type and assert that endpoints only
accept JSON as input.

Introduce empty response for Connect for consistency of JSON response.

Add utilities to marshal and unmarshal request/responses.