### PR TITLE
Engine fails if no callback has been registered

### DIFF
--- a/core/engine/engine.go
+++ b/core/engine/engine.go
@@ -192,7 +192,8 @@ func (e *Engine) GetAdv(ctx context.Context, c cid.Cid) (schema.Advertisement, e
 		return nil, err
 	}
 
-	n, err := e.lsys.Load(ipld.LinkContext{}, l, schema.Type.Advertisement)
+	lsys := e.vanillaLinkSystem()
+	n, err := lsys.Load(ipld.LinkContext{}, l, schema.Type.Advertisement)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-indexer-core"
+	"github.com/filecoin-project/indexer-reference-provider/core"
 	schema "github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -20,6 +21,24 @@ import (
 )
 
 var prefix = schema.Linkproto.Prefix
+
+// ToCallback simply returns the list of CIDs for
+// testing purposes. A more complex callback could read
+// from the CID index and return the list of CIDs.
+func ToCallback(cids []cid.Cid) core.CidCallback {
+	return func(k core.LookupKey) (<-chan cid.Cid, <-chan error) {
+		chcid := make(chan cid.Cid, 1)
+		err := make(chan error, 1)
+		go func() {
+			defer close(chcid)
+			defer close(err)
+			for _, c := range cids {
+				chcid <- c
+			}
+		}()
+		return chcid, err
+	}
+}
 
 func RandomCids(n int) ([]cid.Cid, error) {
 	prng := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/server/provider/libp2p/protocol_test.go
+++ b/server/provider/libp2p/protocol_test.go
@@ -24,7 +24,10 @@ func mkEngine(t *testing.T, h host.Host, testTopic string) (*engine.Engine, erro
 	require.NoError(t, err)
 	store := dssync.MutexWrap(datastore.NewMapDatastore())
 
-	return engine.New(context.Background(), priv, h, store, testTopic)
+	cids, _ := utils.RandomCids(10)
+	e, err := engine.New(context.Background(), priv, h, store, testTopic)
+	e.RegisterCidCallback(utils.ToCallback(cids))
+	return e, err
 }
 
 func setupServer(ctx context.Context, t *testing.T) (*libp2pserver.Server, host.Host, *engine.Engine) {


### PR DESCRIPTION
This PR:
- Removes the cast of `LookupKey` as CID by default.
- Forces users to register a proper callback in the engine to translate from `LookupKey` to list of CIDs.

_(@masih you were right. After tinkering a bit with the use of a default callback, it made the code really dirty and it wasn't actually  doing any good to users, as they had to still worry about storing the list of CIDs in the right format in the blockstore. Going with your approach, where the engine fails if no callback has been registered. Let me know what you think)_