### PR TITLE
Add logs to core engine

### DIFF
--- a/core/engine/engine.go
+++ b/core/engine/engine.go
@@ -24,7 +24,7 @@ import (
 	legs "github.com/willscott/go-legs"
 )
 
-var log = logging.Logger("reference-provider/engine")
+var log = logging.Logger("provider/engine")
 
 var _ core.Interface = &Engine{}
 

--- a/server/provider/libp2p/handler.go
+++ b/server/provider/libp2p/handler.go
@@ -60,6 +60,7 @@ func (h *handler) HandleMessage(ctx context.Context, msgPeer peer.ID, msgbytes [
 
 	data, err := handle(ctx, msgPeer, &req)
 	if err != nil {
+		log.Errorf("Error handling message: %w", err)
 		rspType = pb.ProviderMessage_ERROR_RESPONSE
 		data = v0.EncodeError(err)
 	}


### PR DESCRIPTION
This PR adds `Error` and some `Debug` logs to the core engine. 