### PR TITLE
Replace `LookupKey` concept with `ContextID`

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -33,8 +33,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testTopic = "indexer/test"
-const protocolID = 0x300000
+const (
+	testTopic  = "indexer/test"
+	protocolID = 0x300000
+)
 
 func mkLinkSystem(ds datastore.Batching) ipld.LinkSystem {
 	lsys := cidlink.DefaultLinkSystem()
@@ -125,16 +127,16 @@ func prepareMhsForCallback(t *testing.T, e *Engine, mhs []mh.Multihash) ipld.Lin
 	// Register a callback that returns the randomly generated
 	// list of cids.
 	e.RegisterCallback(utils.ToCallback(mhs))
-	// Use a random key for the list of cids.
-	key := []byte(mhs[0])
-	mhIter, err := e.cb(context.Background(), key)
+	// Use a random contextID for the list of cids.
+	contextID := []byte(mhs[0])
+	mhIter, err := e.cb(context.Background(), contextID)
 	require.NoError(t, err)
 	cidsLnk, err := generateChunks(noStoreLinkSystem(), mhIter, maxIngestChunk)
 	require.NoError(t, err)
-	// Store the relationship between lookupKey and CID
+	// Store the relationship between contextID and CID
 	// of the advertised list of Cids so it is available
 	// for the engine.
-	err = e.putKeyCidMap(key, cidsLnk.(cidlink.Link).Cid)
+	err = e.putKeyCidMap(contextID, cidsLnk.(cidlink.Link).Cid)
 	require.NoError(t, err)
 	return cidsLnk
 }

--- a/interface.go
+++ b/interface.go
@@ -10,12 +10,6 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
-// LookupKey represents the key that uniquely identifies a list of multihashes
-// looked up via Callback.
-//
-// See: Interface.NotifyPut, Interface.NotifyRemove, ProviderCallback.
-type LookupKey []byte
-
 // Interface represents an index provider that manages the advertisement of
 // multihashes to indexer nodes.
 type Interface interface {
@@ -34,13 +28,13 @@ type Interface interface {
 	Publish(context.Context, schema.Advertisement) (cid.Cid, error)
 
 	// RegisterCallback registers the callback used by the provider to look up
-	// a list of multihashes by LookupKey.  Only a single callback is
+	// a list of multihashes by context ID.  Only a single callback is
 	// supported; repeated calls to this function will replace the previous
 	// callback.
 	RegisterCallback(Callback)
 
 	// NotifyPut sginals to the provider that the list of multihashes looked up
-	// by the given key are available.  The given key is then used to look up
+	// by the given contextID are available.  The given contextID is then used to look up
 	// the list of multihashes via Callback.  An advertisement is then
 	// generated, appended to the chain of advertisements and published onto
 	// the gossip pubsub channel.  Therefore, a Callback must be registered
@@ -51,16 +45,16 @@ type Interface interface {
 	// ID, but its data is optional.
 	//
 	// This function returns the ID of the advertisement published.
-	NotifyPut(context.Context, LookupKey, stiapi.Metadata) (cid.Cid, error)
+	NotifyPut(ctx context.Context, contextID []byte, metadata stiapi.Metadata) (cid.Cid, error)
 
 	// NotifyRemove sginals to the provider that the multihashes that
-	// corresponded to the given key are no longer available.  An advertisement
+	// corresponded to the given contextID are no longer available.  An advertisement
 	// is then generated, appended to the chain of advertisements and published
-	// onto the gossip pubsub channel.  The given key must have previously been
+	// onto the gossip pubsub channel.  The given contextID must have previously been
 	// put via NotifyPut.
 	//
 	// This function returns the ID of the advertisement published.
-	NotifyRemove(context.Context, LookupKey) (cid.Cid, error)
+	NotifyRemove(ctx context.Context, contextID []byte) (cid.Cid, error)
 
 	// GetAdv gets the advertisement that corresponds to the given cid.
 	GetAdv(context.Context, cid.Cid) (schema.Advertisement, error)
@@ -85,8 +79,8 @@ type MultihashIterator interface {
 }
 
 // Callback is used by provider to look up a list of multihashes associated to
-// a key.  The callback must produce the same list of multihashes for the same
-// key.
+// a context ID.  The callback must produce the same list of multihashes for the same
+// context ID.
 //
-// See: Interface.NotifyPut, Interface.NotifyRemove, MultihashIterator
-type Callback func(ctx context.Context, key LookupKey) (MultihashIterator, error)
+// See: Interface.NotifyPut, Interface.NotifyRemove, MultihashIterator.
+type Callback func(ctx context.Context, contextID []byte) (MultihashIterator, error)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -44,7 +44,7 @@ func (s *sliceMhIterator) Next() (mh.Multihash, error) {
 // testing purposes. A more complex callback could read
 // from the CID index and return the list of multihashes.
 func ToCallback(mhs []mh.Multihash) provider.Callback {
-	return func(_ context.Context, _ provider.LookupKey) (provider.MultihashIterator, error) {
+	return func(_ context.Context, _ []byte) (provider.MultihashIterator, error) {
 		return &sliceMhIterator{mhs: mhs}, nil
 	}
 }

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -71,33 +71,33 @@ func (mr *MockInterfaceMockRecorder) GetLatestAdv(arg0 interface{}) *gomock.Call
 }
 
 // NotifyPut mocks base method.
-func (m *MockInterface) NotifyPut(arg0 context.Context, arg1 provider.LookupKey, arg2 v0.Metadata) (cid.Cid, error) {
+func (m *MockInterface) NotifyPut(ctx context.Context, contextID []byte, metadata v0.Metadata) (cid.Cid, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NotifyPut", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "NotifyPut", ctx, contextID, metadata)
 	ret0, _ := ret[0].(cid.Cid)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NotifyPut indicates an expected call of NotifyPut.
-func (mr *MockInterfaceMockRecorder) NotifyPut(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) NotifyPut(ctx, contextID, metadata interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyPut", reflect.TypeOf((*MockInterface)(nil).NotifyPut), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyPut", reflect.TypeOf((*MockInterface)(nil).NotifyPut), ctx, contextID, metadata)
 }
 
 // NotifyRemove mocks base method.
-func (m *MockInterface) NotifyRemove(arg0 context.Context, arg1 provider.LookupKey) (cid.Cid, error) {
+func (m *MockInterface) NotifyRemove(ctx context.Context, contextID []byte) (cid.Cid, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NotifyRemove", arg0, arg1)
+	ret := m.ctrl.Call(m, "NotifyRemove", ctx, contextID)
 	ret0, _ := ret[0].(cid.Cid)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NotifyRemove indicates an expected call of NotifyRemove.
-func (mr *MockInterfaceMockRecorder) NotifyRemove(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) NotifyRemove(ctx, contextID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyRemove", reflect.TypeOf((*MockInterface)(nil).NotifyRemove), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyRemove", reflect.TypeOf((*MockInterface)(nil).NotifyRemove), ctx, contextID)
 }
 
 // Publish mocks base method.

--- a/server/admin/http/importcar_handler.go
+++ b/server/admin/http/importcar_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/filecoin-project/indexer-reference-provider"
 	"github.com/filecoin-project/indexer-reference-provider/internal/suppliers"
 	"github.com/ipfs/go-cid"
 )
@@ -26,17 +25,17 @@ func (h *importCarHandler) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Supply CAR.
-	var key provider.LookupKey
+	var contextID []byte
 	var advId cid.Cid
 	var err error
 	ctx := context.Background()
 	if req.hasId() {
-		key = req.Key
-		log.Info("Storing car with specified key")
+		contextID = req.Key
+		log.Info("Storing car with specified contextID")
 		advId, err = h.cs.PutWithID(ctx, req.Key, req.Path, req.Metadata)
 	} else {
-		log.Info("Storing CAR and generating key")
-		key, advId, err = h.cs.Put(ctx, req.Path, req.Metadata)
+		log.Info("Storing CAR and generating contextID")
+		contextID, advId, err = h.cs.Put(ctx, req.Path, req.Metadata)
 	}
 
 	// Respond with cause of failure.
@@ -47,10 +46,10 @@ func (h *importCarHandler) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Infow("Stored CAR", "path", req.Path, "key", key)
+	log.Infow("Stored CAR", "path", req.Path, "contextID", contextID)
 
 	// Respond with successful import results.
-	resp := &ImportCarRes{key, advId}
+	resp := &ImportCarRes{contextID, advId}
 	respond(w, http.StatusOK, resp)
 }
 

--- a/server/admin/http/models.go
+++ b/server/admin/http/models.go
@@ -26,7 +26,7 @@ type (
 	ImportCarReq struct {
 		// The path to the CAR file
 		Path string `json:"path"`
-		// The optional lookup key associated to the CAR. If not provided, one will be generated.
+		// The optional key associated to the CAR. If not provided, one will be generated.
 		Key []byte `json:"key"`
 		// The optional metadata.
 		Metadata stiapi.Metadata `json:"metadata"`


### PR DESCRIPTION
Remove the `LookupKey` type in favour of `[]byte` that represents
"Context ID", an ID used already bo go-indexer-core to aggregate
metadata. For provider's purposes this results in 1:1 functionaly with
`LookupKey`, since a "Context ID" will always return the same list of
multihashes.