### PR TITLE
Define Filecoin Metadata types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/ipfs/go-datastore v0.4.6
 	github.com/ipfs/go-ds-leveldb v0.4.2
 	github.com/ipfs/go-graphsync v0.9.3
+	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-log/v2 v2.3.0
 	github.com/ipld/go-car/v2 v2.0.3-0.20210920144420-f35d88ce16ca
 	github.com/ipld/go-ipld-prime v0.12.0

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,0 +1,159 @@
+package metadata
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+// DataTransferProtocolID is the protocol id that indicates an piece of content
+// is served over the data transport protocol
+// TBD: choose a number -- should Protocol be a multicodec? It's not really
+// and encoding format -- it's a protocol -- or maybe we're ultimately just
+// describing a metadata encoding format?
+const DataTransferProtocolID = 0x300001
+
+// ExchangeFormat identifies a protocol for exchanging vouchers over data transfer
+type ExchangeFormat string
+
+// TransportProtocol indicates the underlying transport data transfer will use
+// Note: while currently go-data-transfer supports only graphsync, this is part
+// of the metadata to future proof for multiple transport protocols
+type TransportProtocol string
+
+// DataTransferMetadata is the CBOR serialized data encoded in the
+// metadata bytes when the multicodec is DataTransferProtocolID
+type DataTransferMetadata struct {
+	// ExchangeFormat identifies the type of vouchers taht will be exchanged
+	ExchangeFormat ExchangeFormat
+	// Transport indicates the underlying protocol (for now, always graphsync)
+	TransportProtocol TransportProtocol
+	// FormatData is opaque bytes that can be decoded once you know the format type
+	FormatData []byte
+}
+
+const (
+	// FilecoinV1 is the current filecoin retrieval protocol
+	FilecoinV1 ExchangeFormat = "/filecoin-exchange/1.0.0"
+
+	// GraphSync is the name of actual graphsync libp2p protocol
+	GraphSync TransportProtocol = "/ipfs/graphsync/1.0.0"
+)
+
+// FilecoinV1Data is the information encoded in FormatDat for FilecoinV1
+type FilecoinV1Data struct {
+	// PieceCID identifies the piece this data can be found in
+	PieceCID datamodel.Link
+	// Free indicates if the retrieval is free
+	IsFree bool
+	// FastRetrieval indicates whether the provider claims there is an unsealed copy
+	FastRetrieval bool
+}
+
+var dataTransferSchemaType schema.Type
+var filecoinvV1SchemaType schema.Type
+
+func init() {
+	ts := schema.TypeSystem{}
+	ts.Init()
+	ts.Accumulate(schema.SpawnString("String"))
+	ts.Accumulate(schema.SpawnBytes("Bytes"))
+	ts.Accumulate(schema.SpawnLink("Link"))
+	ts.Accumulate(schema.SpawnBool("Bool"))
+	ts.Accumulate(schema.SpawnStruct("DataTransferMetadata",
+		[]schema.StructField{
+			schema.SpawnStructField("ExchangeFormat", "String", false, false),
+			schema.SpawnStructField("TransportProtocol", "String", false, false),
+			schema.SpawnStructField("FormatData", "Bytes", false, false),
+		},
+		schema.SpawnStructRepresentationMap(nil),
+	))
+	ts.Accumulate(schema.SpawnStruct("FilecoinV1Data",
+		[]schema.StructField{
+			schema.SpawnStructField("PieceCID", "Link", false, false),
+			schema.SpawnStructField("IsFree", "Bool", false, false),
+			schema.SpawnStructField("FastRetrieval", "Bool", false, false),
+		},
+		schema.SpawnStructRepresentationMap(nil),
+	))
+	dataTransferSchemaType = ts.TypeByName("DataTransferMetadata")
+	filecoinvV1SchemaType = ts.TypeByName("FilecoinV1Data")
+}
+
+// EncodeDataTransferMetadata writes DataTransferMetadata to a byte stream
+func EncodeDataTransferMetadata(dtm *DataTransferMetadata, w io.Writer) error {
+	nd := bindnode.Wrap(dtm, dataTransferSchemaType)
+	return dagcbor.Encode(nd, w)
+}
+
+// EncodeDataTransferMetadataToBytes writes a serialized byte array for the given
+// DataTransferMetadata
+func EncodeDataTransferMetadataToBytes(dtm *DataTransferMetadata) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	err := EncodeDataTransferMetadata(dtm, buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeDataTransferMetadata reads a new DataTransferMetadata instance from
+// a byte stream
+func DecodeDataTransferMetadata(r io.Reader) (*DataTransferMetadata, error) {
+	proto := bindnode.Prototype((*DataTransferMetadata)(nil), dataTransferSchemaType)
+	nb := proto.NewBuilder()
+	err := dagcbor.Decode(nb, r)
+	if err != nil {
+		return nil, err
+	}
+	nd := nb.Build()
+	return bindnode.Unwrap(nd).(*DataTransferMetadata), nil
+}
+
+// DecodeDataTransferMetadataFromBytes reads a new DataTransferMetadata instance from
+// serialized byte array
+func DecodeDataTransferMetadataFromBytes(serialized []byte) (*DataTransferMetadata, error) {
+	r := bytes.NewBuffer(serialized)
+	return DecodeDataTransferMetadata(r)
+}
+
+// EncodeFilecoinV1Data writes FilecoinV1Data to a byte stream
+func EncodeFilecoinV1Data(fd *FilecoinV1Data, w io.Writer) error {
+	nd := bindnode.Wrap(fd, filecoinvV1SchemaType)
+	return dagcbor.Encode(nd, w)
+}
+
+// EncodeFilecoinV1DataToBytes writes a serialized byte array for the given
+// FilecoinV1Data
+func EncodeFilecoinV1DataToBytes(fd *FilecoinV1Data) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	err := EncodeFilecoinV1Data(fd, buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeFilecoinV1Data reads a new FilecoinV1Data instance from
+// a byte stream
+func DecodeFilecoinV1Data(r io.Reader) (*FilecoinV1Data, error) {
+	proto := bindnode.Prototype((*FilecoinV1Data)(nil), filecoinvV1SchemaType)
+	nb := proto.NewBuilder()
+	err := dagcbor.Decode(nb, r)
+	if err != nil {
+		return nil, err
+	}
+	nd := nb.Build()
+	return bindnode.Unwrap(nd).(*FilecoinV1Data), nil
+}
+
+// DecodeFilecoinV1DataFromBytes reads a new FilecoinV1Data instance from
+// serialized byte array
+func DecodeFilecoinV1DataFromBytes(serialized []byte) (*FilecoinV1Data, error) {
+	r := bytes.NewBuffer(serialized)
+	return DecodeFilecoinV1Data(r)
+}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1,12 +1,14 @@
 package metadata_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/filecoin-project/indexer-reference-provider/metadata"
 	"github.com/ipfs/go-cid"
 	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/multiformats/go-multicodec"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,21 +37,64 @@ func TestRoundTripDataTransferFilecoin(t *testing.T) {
 		},
 	}
 	for _, srcFilecoinV1Data := range filecoinV1Datas {
-		filecoinV1Bytes, err := metadata.EncodeFilecoinV1DataToBytes(srcFilecoinV1Data)
+		srcDataTransferMetadata, err := srcFilecoinV1Data.Encode(metadata.GraphSyncV1)
 		require.NoError(t, err)
-		srcDataTransferMetadata := &metadata.DataTransferMetadata{
-			ExchangeFormat:    metadata.FilecoinV1,
-			TransportProtocol: metadata.GraphSync,
-			FormatData:        filecoinV1Bytes,
-		}
-		dataTransferBytes, err := metadata.EncodeDataTransferMetadataToBytes(srcDataTransferMetadata)
-		require.NoError(t, err)
-		dstDataTransferMetadata, err := metadata.DecodeDataTransferMetadataFromBytes(dataTransferBytes)
+		require.Equal(t, srcDataTransferMetadata.ExchangeFormat(), metadata.FilecoinV1)
+		require.Equal(t, srcDataTransferMetadata.TransportProtocol(), metadata.GraphSyncV1)
+		indexerMetadata := srcDataTransferMetadata.ToIndexerMetadata()
+		require.Equal(t, multicodec.Code(0x3F0000), indexerMetadata.ProtocolID)
+		dstDataTransferMetadata, err := metadata.FromIndexerMetadata(indexerMetadata)
 		require.NoError(t, err)
 		require.Equal(t, srcDataTransferMetadata, dstDataTransferMetadata)
-		dstFilecoinV1Data, err := metadata.DecodeFilecoinV1DataFromBytes(dstDataTransferMetadata.FormatData)
+		dstFilecoinV1Data, err := metadata.DecodeFilecoinV1Data(dstDataTransferMetadata)
 		require.NoError(t, err)
 		require.Equal(t, srcFilecoinV1Data, dstFilecoinV1Data)
+	}
+}
+
+func TestFormatDetection(t *testing.T) {
+	cids := generateCids(1)
+	filecoinV1Data := &metadata.FilecoinV1Data{
+		PieceCID:      cidlink.Link{Cid: cids[0]},
+		IsFree:        false,
+		FastRetrieval: false,
+	}
+	dataTransferMetadata, err := filecoinV1Data.Encode(metadata.GraphSyncV1)
+	require.NoError(t, err)
+	indexerMetadata := dataTransferMetadata.ToIndexerMetadata()
+	testCases := []struct {
+		protocol    multicodec.Code
+		expectedErr error
+	}{
+		{
+			protocol:    0x13F0000,
+			expectedErr: errors.New("protocol 0x13F0000 is not a data transfer protocol"),
+		},
+		{
+			protocol:    0x310000,
+			expectedErr: errors.New("protocol 0x310000 is not a data transfer protocol"),
+		},
+		{
+			protocol:    0x3F0100,
+			expectedErr: errors.New("protocol 0x3F0100 does not use the FilecoinV1 exchange format"),
+		},
+		{
+			protocol:    0x3F0001,
+			expectedErr: nil,
+		},
+	}
+	for _, testCase := range testCases {
+		indexerMetadata.ProtocolID = testCase.protocol
+		var err error
+		dataTransferMetadata, err = metadata.FromIndexerMetadata(indexerMetadata)
+		if err == nil {
+			_, err = metadata.DecodeFilecoinV1Data(dataTransferMetadata)
+		}
+		if testCase.expectedErr == nil {
+			require.NoError(t, err)
+		} else {
+			require.EqualError(t, err, testCase.expectedErr.Error())
+		}
 	}
 }
 

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1,0 +1,65 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/indexer-reference-provider/metadata"
+	"github.com/ipfs/go-cid"
+	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripDataTransferFilecoin(t *testing.T) {
+	cids := generateCids(4)
+	filecoinV1Datas := []*metadata.FilecoinV1Data{
+		{
+			PieceCID:      cidlink.Link{Cid: cids[0]},
+			IsFree:        false,
+			FastRetrieval: false,
+		},
+		{
+			PieceCID:      cidlink.Link{Cid: cids[1]},
+			IsFree:        false,
+			FastRetrieval: true,
+		},
+		{
+			PieceCID:      cidlink.Link{Cid: cids[2]},
+			IsFree:        true,
+			FastRetrieval: true,
+		},
+		{
+			PieceCID:      cidlink.Link{Cid: cids[3]},
+			IsFree:        true,
+			FastRetrieval: true,
+		},
+	}
+	for _, srcFilecoinV1Data := range filecoinV1Datas {
+		filecoinV1Bytes, err := metadata.EncodeFilecoinV1DataToBytes(srcFilecoinV1Data)
+		require.NoError(t, err)
+		srcDataTransferMetadata := &metadata.DataTransferMetadata{
+			ExchangeFormat:    metadata.FilecoinV1,
+			TransportProtocol: metadata.GraphSync,
+			FormatData:        filecoinV1Bytes,
+		}
+		dataTransferBytes, err := metadata.EncodeDataTransferMetadataToBytes(srcDataTransferMetadata)
+		require.NoError(t, err)
+		dstDataTransferMetadata, err := metadata.DecodeDataTransferMetadataFromBytes(dataTransferBytes)
+		require.NoError(t, err)
+		require.Equal(t, srcDataTransferMetadata, dstDataTransferMetadata)
+		dstFilecoinV1Data, err := metadata.DecodeFilecoinV1DataFromBytes(dstDataTransferMetadata.FormatData)
+		require.NoError(t, err)
+		require.Equal(t, srcFilecoinV1Data, dstFilecoinV1Data)
+	}
+}
+
+var blockGenerator = blocksutil.NewBlockGenerator()
+
+func generateCids(n int) []cid.Cid {
+	cids := make([]cid.Cid, 0, n)
+	for i := 0; i < n; i++ {
+		c := blockGenerator.Next().Cid()
+		cids = append(cids, c)
+	}
+	return cids
+}


### PR DESCRIPTION
# Goals

Implement #52 

# Implementation

Define:
- Protocol Multicodec for using data transfer
- DataTransferMetadata
- Filecoin specific data
- Encoding and decoding rules (basically, use CBOR)
- Functions to encode/decode

# For Discussion

Re: where to put this - perhaps it shouldn't be in this repo, but also, why not leave it here till we figure out a better place

Protocol decisions:

1. I feel pretty strongly the actual "protocol" is data transfer. Data Transfer should support multiple transport protocols and multiple exchange formats. The important thing this tells you is you are going to transfer this with the Data Transfer Protocol, regardless of the underlying transport. This doesn't mean there isn't a future raw "Graphsync" protocol -- IPFS might offer this at some point. Bitswap might too. But they are still distinct.

2. Why add a TransportProtocol when go-data-transfer supports go-graphsync only? Cause it should support more, and if we have to add it later, we have to upgrade.

