### PR TITLE
Export explicit error types for unknwon `contextID`

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -31,9 +31,6 @@ var _ provider.Interface = (*Engine)(nil)
 // maxIngestChunk is the maximum number of entries to include in each chunk of ingestion linked list.
 const maxIngestChunk = 100
 
-// ErrNoCallback is thrown when no callback has been defined.
-var ErrNoCallback = errors.New("no callback is registered")
-
 // Engine is an implementation of the core reference provider interface
 type Engine struct {
 	// privKey is the provider's privateKey
@@ -207,7 +204,7 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metad
 	// If no callback registered return error
 	if e.cb == nil {
 		log.Error("No callback defined in engine")
-		return cid.Undef, ErrNoCallback
+		return cid.Undef, provider.ErrNoCallback
 	}
 
 	// If we are not removing, we need to generate the link for the list
@@ -243,6 +240,9 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metad
 		c, err := e.getKeyCidMap(contextID)
 		if err != nil {
 			log.Errorf("Could not get mapping between contextID and CID of linked list (%s): %s", string(contextID), err)
+			if err == datastore.ErrNotFound {
+				return cid.Undef, provider.ErrContextIDNotFound
+			}
 			return cid.Undef, err
 		}
 		cidsLnk = cidlink.Link{Cid: c}

--- a/engine/linksystem.go
+++ b/engine/linksystem.go
@@ -58,7 +58,7 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 		// If no callback registered return error
 		if e.cb == nil {
 			log.Error("No callback has been registered in engine")
-			return nil, ErrNoCallback
+			return nil, provider.ErrNoCallback
 		}
 
 		log.Debugw("Checking cache for data", "cid", c)
@@ -308,9 +308,6 @@ func (e *Engine) getCidKeyMap(c cid.Cid) ([]byte, error) {
 func (e *Engine) getKeyCidMap(contextID []byte) (cid.Cid, error) {
 	b, err := e.ds.Get(datastore.NewKey(keyToCidMapPrefix + string(contextID)))
 	if err != nil {
-		if err == datastore.ErrNotFound {
-			return cid.Undef, nil
-		}
 		return cid.Undef, err
 	}
 	_, d, err := cid.CidFromBytes(b)

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,11 @@
+package provider
+
+import "errors"
+
+var (
+	// ErrNoCallback is thrown when no callback has been defined.
+	ErrNoCallback = errors.New("no callback is registered")
+
+	// ErrContextIDNotFound signals that no item is associated to the given context ID.
+	ErrContextIDNotFound = errors.New("context ID not found")
+)

--- a/interface.go
+++ b/interface.go
@@ -37,8 +37,9 @@ type Interface interface {
 	// by the given contextID are available.  The given contextID is then used to look up
 	// the list of multihashes via Callback.  An advertisement is then
 	// generated, appended to the chain of advertisements and published onto
-	// the gossip pubsub channel.  Therefore, a Callback must be registered
-	// prior to using this function.
+	// the gossip pubsub channel.
+	// Therefore, a Callback must be registered prior to using this function.
+	// ErrNoCallback is returned if no such callback is registered.
 	//
 	// The metadata is data that provides hints about how to retrieve data and
 	// is protocol dependant.  The metadata must at least specify a protocol
@@ -50,8 +51,9 @@ type Interface interface {
 	// NotifyRemove sginals to the provider that the multihashes that
 	// corresponded to the given contextID are no longer available.  An advertisement
 	// is then generated, appended to the chain of advertisements and published
-	// onto the gossip pubsub channel.  The given contextID must have previously been
-	// put via NotifyPut.
+	// onto the gossip pubsub channel.
+	// The given contextID must have previously been put via NotifyPut.
+	// If not found ErrContextIDNotFound is returned.
 	//
 	// This function returns the ID of the advertisement published.
 	NotifyRemove(ctx context.Context, contextID []byte) (cid.Cid, error)


### PR DESCRIPTION
Export an explicit error type to signal that a `contextID` is never seen
before if given to `NotifyRemove`.

While at it, move the known error type for no registered callback out of
engine and onto `provider` package.

Update docs and add tests.