### PR TITLE
Use native cid.Cid format in FilecoinV1Metadata struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-log/v2 v2.3.0
 	github.com/ipld/go-car/v2 v2.0.3-0.20210920144420-f35d88ce16ca
-	github.com/ipld/go-ipld-prime v0.12.0
+	github.com/ipld/go-ipld-prime v0.12.4-0.20211018101421-492705d1efdc
 	github.com/libp2p/go-libp2p v0.15.0
 	github.com/libp2p/go-libp2p-core v0.9.0
 	github.com/libp2p/go-msgio v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,9 @@ github.com/ipld/go-codec-dagpb v1.3.0 h1:czTcaoAuNNyIYWs6Qe01DJ+sEX7B+1Z0LcXjSat
 github.com/ipld/go-codec-dagpb v1.3.0/go.mod h1:ga4JTU3abYApDC3pZ00BC2RSvC3qfBb9MSJkMLSwnhA=
 github.com/ipld/go-ipld-prime v0.0.2-0.20191108012745-28a82f04c785/go.mod h1:bDDSvVz7vaK12FNvMeRYnpRFkSUPNQOiCYQezMD/P3w=
 github.com/ipld/go-ipld-prime v0.11.0/go.mod h1:+WIAkokurHmZ/KwzDOMUuoeJgaRQktHtEaLglS3ZeV8=
-github.com/ipld/go-ipld-prime v0.12.0 h1:JapyKWTsJgmhrPI7hfx4V798c/RClr85sXfBZnH1VIw=
 github.com/ipld/go-ipld-prime v0.12.0/go.mod h1:hy8b93WleDMRKumOJnTIrr0MbbFbx9GD6Kzxa53Xppc=
+github.com/ipld/go-ipld-prime v0.12.4-0.20211018101421-492705d1efdc h1:pujHrFF6v3nZBsjgpkLtCXdiUFd4R9Hbn9C7s00hYlw=
+github.com/ipld/go-ipld-prime v0.12.4-0.20211018101421-492705d1efdc/go.mod h1:PaeLYq8k6dJLmDUSLrzkEpoGV4PEfe/1OtFN/eALOc8=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5/go.mod h1:gcvzoEDBjwycpXt3LBE061wT9f46szXGHAmj9uoP6fU=
 github.com/ipld/go-storethehash v0.0.0-20210915160027-d72ca9b0968c/go.mod h1:PwE6iq8TiWJRI3zMGA1RtkFAnrDMK93dLA5SUeu0lH8=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	stiapi "github.com/filecoin-project/storetheindex/api/v0"
+	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
-	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/node/bindnode"
 	"github.com/ipld/go-ipld-prime/schema"
 	"github.com/multiformats/go-multicodec"
@@ -69,7 +69,7 @@ const (
 // FilecoinV1Data is the information encoded in Data for FilecoinGraphsyncV1
 type FilecoinV1Data struct {
 	// PieceCID identifies the piece this data can be found in
-	PieceCID datamodel.Link
+	PieceCID cid.Cid
 	// Free indicates if the retrieval is free
 	IsFree bool
 	// FastRetrieval indicates whether the provider claims there is an unsealed copy

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/filecoin-project/indexer-reference-provider/metadata"
 	"github.com/ipfs/go-cid"
 	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
-	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/multiformats/go-multicodec"
 	"github.com/stretchr/testify/require"
 )
@@ -16,22 +15,22 @@ func TestRoundTripDataTransferFilecoin(t *testing.T) {
 	cids := generateCids(4)
 	filecoinV1Datas := []*metadata.FilecoinV1Data{
 		{
-			PieceCID:      cidlink.Link{Cid: cids[0]},
+			PieceCID:      cids[0],
 			IsFree:        false,
 			FastRetrieval: false,
 		},
 		{
-			PieceCID:      cidlink.Link{Cid: cids[1]},
+			PieceCID:      cids[1],
 			IsFree:        false,
 			FastRetrieval: true,
 		},
 		{
-			PieceCID:      cidlink.Link{Cid: cids[2]},
+			PieceCID:      cids[2],
 			IsFree:        true,
 			FastRetrieval: true,
 		},
 		{
-			PieceCID:      cidlink.Link{Cid: cids[3]},
+			PieceCID:      cids[3],
 			IsFree:        true,
 			FastRetrieval: true,
 		},
@@ -55,7 +54,7 @@ func TestRoundTripDataTransferFilecoin(t *testing.T) {
 func TestFormatDetection(t *testing.T) {
 	cids := generateCids(1)
 	filecoinV1Data := &metadata.FilecoinV1Data{
-		PieceCID:      cidlink.Link{Cid: cids[0]},
+		PieceCID:      cids[0],
 		IsFree:        false,
 		FastRetrieval: false,
 	}


### PR DESCRIPTION
# Goals

Uses @mvdan 's PR to go-ipld-prime so we can use a native cid.Cid with bind node, allowing our FilecoinV1Metadata to use a cid.Cid directly rather than a datamodel.Link