### PR TITLE
Link cache is now datastore-backed LRU cache 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(BIN): vet test
 lint:
 	golangci-lint run
 
-mock: interface.go
+mock/interface.go: interface.go
 	mockgen --source interface.go --destination mock/interface.go --package mock_provider
 
 test: mock

--- a/config/config.go
+++ b/config/config.go
@@ -92,6 +92,7 @@ func Load(filePath string) (*Config, error) {
 	if err := json.NewDecoder(f).Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("failure to decode config: %s", err)
 	}
+
 	return &cfg, err
 }
 

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -9,6 +9,6 @@ const (
 type Datastore struct {
 	// Type is the type of datastore
 	Type string
-	// Dir is the directory withing the config root where the datastore is kept
+	// Dir is the directory within the config root where the datastore is kept
 	Dir string
 }

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -1,11 +1,35 @@
 package config
 
 const (
-	defaultIngestPubSubTopic = "indexer/ingest"
+	defaultLinkCacheSize   = 1024
+	defaultLinkedChunkSize = 100
+	defaultPubSubTopic     = "indexer/ingest"
 )
 
 // Ingest tracks the configuration related to the ingestion protocol
 type Ingest struct {
+	// LinkCacheSize is the maximum number of links that cash can store before LRU eviction.  If a
+	// single linked list has more links than the cache can hold, the cache is
+	// resized to be able to hold all links.
+	LinkCacheSize int
+	// LinkedChunkSize is the number of hashes in each chunk of ingestion
+	// linked list.
+	LinkedChunkSize int
 	// PubSubTopic used to advertise ingestion announcements.
 	PubSubTopic string
+	// PurgeLinkCache tells whether to purge the link cache on daemon startup.
+	PurgeLinkCache bool
+}
+
+// Defaults replaces zero-values in the config with default values.
+func (cfg *Ingest) Defaults() {
+	if cfg.LinkCacheSize == 0 {
+		cfg.LinkCacheSize = defaultLinkCacheSize
+	}
+	if cfg.LinkedChunkSize == 0 {
+		cfg.LinkedChunkSize = defaultLinkedChunkSize
+	}
+	if cfg.PubSubTopic == "" {
+		cfg.PubSubTopic = defaultPubSubTopic
+	}
 }

--- a/config/init.go
+++ b/config/init.go
@@ -26,7 +26,9 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 			Dir:  defaultDatastoreDir,
 		},
 		Ingest: Ingest{
-			PubSubTopic: defaultIngestPubSubTopic,
+			LinkCacheSize:   defaultLinkCacheSize,
+			LinkedChunkSize: defaultLinkedChunkSize,
+			PubSubTopic:     defaultPubSubTopic,
 		},
 		ProviderServer: ProviderServer{
 			ListenMultiaddr: defaultNodeMultiaddr,

--- a/e2e_retrieve_test.go
+++ b/e2e_retrieve_test.go
@@ -68,7 +68,7 @@ func setupClient(ctx context.Context, p peer.ID, t *testing.T) (datatransfer.Man
 }
 
 func TestRetrievalRoundTrip(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	// Initialize everything
@@ -96,7 +96,8 @@ func TestRetrievalRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	var receivedMd stiapi.Metadata
-	receivedMd.UnmarshalBinary(r.Ad.Metadata.Bytes())
+	err = receivedMd.UnmarshalBinary(r.Ad.Metadata.Bytes())
+	require.NoError(t, err)
 	dtm, err := metadata.FromIndexerMetadata(receivedMd)
 	require.NoError(t, err)
 	fv1, err := metadata.DecodeFilecoinV1Data(dtm)
@@ -118,8 +119,10 @@ func TestRetrievalRoundTrip(t *testing.T) {
 			resultChan <- true
 		}
 	})
-	clientDt.RegisterVoucherResultType(&cardatatransfer.DealResponse{})
-	clientDt.RegisterVoucherType(&cardatatransfer.DealProposal{}, nil)
+	err = clientDt.RegisterVoucherResultType(&cardatatransfer.DealResponse{})
+	require.NoError(t, err)
+	err = clientDt.RegisterVoucherType(&cardatatransfer.DealProposal{}, nil)
+	require.NoError(t, err)
 	_, err = clientDt.OpenPullDataChannel(ctx, sh.ID(), proposal, roots[0], selectorparse.CommonSelector_ExploreAllRecursively)
 	require.NoError(t, err)
 

--- a/e2e_retrieve_test.go
+++ b/e2e_retrieve_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/indexer-reference-provider/config"
 	"github.com/filecoin-project/indexer-reference-provider/engine"
 	"github.com/filecoin-project/indexer-reference-provider/internal/cardatatransfer"
 	"github.com/filecoin-project/indexer-reference-provider/internal/libp2pserver"
@@ -39,7 +40,10 @@ func setupServer(ctx context.Context, t *testing.T) (*libp2pserver.Server, host.
 	store := dssync.MutexWrap(datastore.NewMapDatastore())
 
 	dt := testutil.SetupDataTransferOnHost(t, h, store, cidlink.DefaultLinkSystem())
-	e, err := engine.New(context.Background(), priv, dt, h, store, "test/topic", nil)
+	ingestCfg := config.Ingest{
+		PubSubTopic: "test/topic",
+	}
+	e, err := engine.New(context.Background(), ingestCfg, priv, dt, h, store, nil)
 	require.NoError(t, err)
 	cs := suppliers.NewCarSupplier(e, store, car.ZeroLengthSectionAsEOF(false))
 	err = cardatatransfer.StartCarDataTransfer(dt, cs)

--- a/engine/dscache.go
+++ b/engine/dscache.go
@@ -1,0 +1,193 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/golang-lru"
+	ds "github.com/ipfs/go-datastore"
+	dsn "github.com/ipfs/go-datastore/namespace"
+	dsq "github.com/ipfs/go-datastore/query"
+)
+
+const linksCachePath = "/cache/links"
+
+// dsCache is a LRU-cache that stores keys in memory and values in a datastore.
+type dsCache struct {
+	capacity int
+	dstore   ds.Datastore
+	lru      *lru.Cache
+}
+
+// newDsCache creates a new dsCache instance.  The context is only used cancel
+// a call to this function while it is accessing the data store.
+func newDsCache(ctx context.Context, dstore ds.Datastore, capacity int, purge bool) (*dsCache, error) {
+	dstore = dsn.Wrap(dstore, ds.NewKey(linksCachePath))
+
+	// Create LRU cache that deletes value from datastore when key is eviceted
+	// from cache.
+	cache, err := lru.NewWithEvict(capacity, func(key, val interface{}) {
+		// Remove item from datastore that was evicted from LRU.
+		dstore.Delete(key.(ds.Key))
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	c := &dsCache{
+		capacity: capacity,
+		dstore:   dstore,
+		lru:      cache,
+	}
+
+	if purge {
+		// Remove all keys from datastore and start with empty cache.
+		if err = c.purgeKeys(ctx); err != nil {
+			return nil, err
+		}
+	} else {
+		// Load all keys from datastore into lru cache.
+		if err = c.loadKeys(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	return c, nil
+}
+
+// Get implements datastore interface.
+func (c *dsCache) Get(key ds.Key) ([]byte, error) {
+	_, ok := c.lru.Get(key)
+	if !ok {
+		return nil, ds.ErrNotFound
+	}
+	val, err := c.dstore.Get(key)
+	if err != nil {
+		if err == ds.ErrNotFound {
+			c.lru.Remove(key)
+		}
+		return nil, err
+	}
+	return val, nil
+}
+
+// Put implements datastore interface.
+func (c *dsCache) Put(key ds.Key, val []byte) error {
+	c.lru.Add(key, nil)
+	return c.dstore.Put(key, val)
+}
+
+// Delete implements datastore interface.
+func (c *dsCache) Delete(key ds.Key) error {
+	if c.lru.Remove(key) {
+		return c.dstore.Delete(key)
+	}
+	return nil
+}
+
+// GetSize implements datastore interface.
+func (c *dsCache) GetSize(key ds.Key) (int, error) {
+	return c.dstore.GetSize(key)
+}
+
+// Has implements datastore interface.
+func (c *dsCache) Has(key ds.Key) (bool, error) {
+	return c.lru.Contains(key), nil
+}
+
+// Sync implements datastore interface.
+func (c *dsCache) Sync(key ds.Key) error {
+	return c.dstore.Sync(key)
+}
+
+// Close implements datastore interface.
+func (c *dsCache) Close() error {
+	return c.dstore.Close()
+}
+
+// Query implements datastore interface.
+func (c *dsCache) Query(q dsq.Query) (dsq.Results, error) {
+	return c.dstore.Query(q)
+}
+
+// Cap returns the cache capacity.  Storing more than this number of items
+// results in discarding oldest items.
+func (c *dsCache) Cap() int {
+	return c.capacity
+}
+
+// Len returns the number of items in the cache.
+func (c *dsCache) Len() int {
+	return c.lru.Len()
+}
+
+// Resize changes the cache capacity. If the capacity is decreased below the
+// number of items in the cache, then oldest items are discarded until the
+// cache is filled to the new lower capacity.
+func (c *dsCache) Resize(newSize int) {
+	c.capacity = newSize
+	c.lru.Resize(newSize)
+}
+
+func (c *dsCache) loadKeys(ctx context.Context) error {
+	q := dsq.Query{
+		KeysOnly: true,
+	}
+
+	results, err := c.dstore.Query(q)
+	if err != nil {
+		return err
+	}
+	defer results.Close()
+
+	var resized bool
+	for r := range results.Next() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if r.Error != nil {
+			return fmt.Errorf("cannot read cache key: %s", r.Error)
+		}
+
+		// Grow cache size as needed to hold items.
+		if c.lru.Len() == c.capacity {
+			c.Resize(c.capacity * 2)
+			resized = true
+		}
+
+		c.lru.Add(ds.RawKey(r.Entry.Key), nil)
+	}
+	// If the cache was resized to expand beyond its original capacity, then
+	// set its size to only as big as the number of keys read from datastore.
+	// This should be the number of links in the largest list.
+	if resized {
+		c.Resize(c.Len())
+	}
+	return nil
+}
+
+func (c *dsCache) purgeKeys(ctx context.Context) error {
+	q := dsq.Query{
+		KeysOnly: true,
+	}
+
+	results, err := c.dstore.Query(q)
+	if err != nil {
+		return err
+	}
+	defer results.Close()
+
+	for r := range results.Next() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if r.Error != nil {
+			return fmt.Errorf("cannot read cache key: %s", r.Error)
+		}
+		if err = c.dstore.Delete(ds.RawKey(r.Entry.Key)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/engine/dscache.go
+++ b/engine/dscache.go
@@ -3,8 +3,9 @@ package engine
 import (
 	"context"
 	"fmt"
+	"sync"
 
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/golang/groupcache/lru"
 	ds "github.com/ipfs/go-datastore"
 	dsn "github.com/ipfs/go-datastore/namespace"
 	dsq "github.com/ipfs/go-datastore/query"
@@ -14,41 +15,37 @@ const linksCachePath = "/cache/links"
 
 // dsCache is a LRU-cache that stores keys in memory and values in a datastore.
 type dsCache struct {
-	capacity int
-	dstore   ds.Datastore
-	lru      *lru.Cache
+	dstore ds.Datastore
+	lru    *lru.Cache
+	lock   sync.RWMutex
 }
 
 // newDsCache creates a new dsCache instance.  The context is only used cancel
 // a call to this function while it is accessing the data store.
-func newDsCache(ctx context.Context, dstore ds.Datastore, capacity int, purge bool) (*dsCache, error) {
+func newDsCache(ctx context.Context, dstore ds.Datastore, capacity int) (*dsCache, error) {
 	dstore = dsn.Wrap(dstore, ds.NewKey(linksCachePath))
 
 	// Create LRU cache that deletes value from datastore when key is eviceted
 	// from cache.
-	cache, err := lru.NewWithEvict(capacity, func(key, val interface{}) {
-		// Remove item from datastore that was evicted from LRU.
-		dstore.Delete(key.(ds.Key))
-	})
-	if err != nil {
+	cache := lru.New(capacity)
+
+	c := &dsCache{
+		dstore: dstore,
+		lru:    cache,
+	}
+
+	// Load all keys from datastore into lru cache.
+	if err := c.loadKeys(ctx); err != nil {
 		return nil, err
 	}
 
-	c := &dsCache{
-		capacity: capacity,
-		dstore:   dstore,
-		lru:      cache,
-	}
-
-	if purge {
-		// Remove all keys from datastore and start with empty cache.
-		if err = c.purgeKeys(ctx); err != nil {
-			return nil, err
-		}
-	} else {
-		// Load all keys from datastore into lru cache.
-		if err = c.loadKeys(ctx); err != nil {
-			return nil, err
+	// Set the function to remove items from the datasotre when they are
+	// evicted from lru.
+	cache.OnEvicted = func(key lru.Key, val interface{}) {
+		// Remove item from datastore that was evicted from LRU.
+		err := dstore.Delete(key.(ds.Key))
+		if err != nil {
+			log.Errorf("Error removing link cache value from datastore: %s", err)
 		}
 	}
 
@@ -57,15 +54,15 @@ func newDsCache(ctx context.Context, dstore ds.Datastore, capacity int, purge bo
 
 // Get implements datastore interface.
 func (c *dsCache) Get(key ds.Key) ([]byte, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
 	_, ok := c.lru.Get(key)
 	if !ok {
 		return nil, ds.ErrNotFound
 	}
 	val, err := c.dstore.Get(key)
 	if err != nil {
-		if err == ds.ErrNotFound {
-			c.lru.Remove(key)
-		}
 		return nil, err
 	}
 	return val, nil
@@ -73,60 +70,112 @@ func (c *dsCache) Get(key ds.Key) ([]byte, error) {
 
 // Put implements datastore interface.
 func (c *dsCache) Put(key ds.Key, val []byte) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	c.lru.Add(key, nil)
 	return c.dstore.Put(key, val)
 }
 
 // Delete implements datastore interface.
 func (c *dsCache) Delete(key ds.Key) error {
-	if c.lru.Remove(key) {
-		return c.dstore.Delete(key)
-	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.lru.Remove(key)
 	return nil
 }
 
 // GetSize implements datastore interface.
 func (c *dsCache) GetSize(key ds.Key) (int, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
 	return c.dstore.GetSize(key)
 }
 
 // Has implements datastore interface.
 func (c *dsCache) Has(key ds.Key) (bool, error) {
-	return c.lru.Contains(key), nil
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.dstore.Has(key)
 }
 
 // Sync implements datastore interface.
 func (c *dsCache) Sync(key ds.Key) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	return c.dstore.Sync(key)
 }
 
 // Close implements datastore interface.
 func (c *dsCache) Close() error {
-	return c.dstore.Close()
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.dstore == nil {
+		return nil
+	}
+
+	if err := c.dstore.Close(); err != nil {
+		return err
+	}
+	c.dstore = nil
+	return nil
 }
 
 // Query implements datastore interface.
 func (c *dsCache) Query(q dsq.Query) (dsq.Results, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
 	return c.dstore.Query(q)
 }
 
 // Cap returns the cache capacity.  Storing more than this number of items
 // results in discarding oldest items.
 func (c *dsCache) Cap() int {
-	return c.capacity
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	return c.lru.MaxEntries
 }
 
 // Len returns the number of items in the cache.
 func (c *dsCache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
 	return c.lru.Len()
 }
 
 // Resize changes the cache capacity. If the capacity is decreased below the
 // number of items in the cache, then oldest items are discarded until the
-// cache is filled to the new lower capacity.
-func (c *dsCache) Resize(newSize int) {
-	c.capacity = newSize
-	c.lru.Resize(newSize)
+// cache is filled to the new lower capacity.  Returns the number of items
+// evicted from cache.
+func (c *dsCache) Resize(newSize int) int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	diff := c.lru.Len() - newSize
+	if diff < 0 {
+		diff = 0
+	}
+	for i := 0; i < diff; i++ {
+		c.lru.RemoveOldest()
+	}
+	c.lru.MaxEntries = newSize
+	return diff
+}
+
+// Clear purges all stored items from the cache.
+func (c *dsCache) Clear() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.lru.Clear()
 }
 
 func (c *dsCache) loadKeys(ctx context.Context) error {
@@ -140,54 +189,27 @@ func (c *dsCache) loadKeys(ctx context.Context) error {
 	}
 	defer results.Close()
 
-	var resized bool
+	origCap := c.lru.MaxEntries
+	c.lru.MaxEntries = 0
+
 	for r := range results.Next() {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 		if r.Error != nil {
 			return fmt.Errorf("cannot read cache key: %s", r.Error)
-		}
-
-		// Grow cache size as needed to hold items.
-		if c.lru.Len() == c.capacity {
-			c.Resize(c.capacity * 2)
-			resized = true
 		}
 
 		c.lru.Add(ds.RawKey(r.Entry.Key), nil)
 	}
+
 	// If the cache was resized to expand beyond its original capacity, then
 	// set its size to only as big as the number of keys read from datastore.
-	// This should be the number of links in the largest list.
-	if resized {
-		c.Resize(c.Len())
+	// This will be the number of links in the largest list.
+	if c.lru.Len() > origCap {
+		c.lru.MaxEntries = c.lru.Len()
+	} else {
+		c.lru.MaxEntries = origCap
 	}
-	return nil
-}
-
-func (c *dsCache) purgeKeys(ctx context.Context) error {
-	q := dsq.Query{
-		KeysOnly: true,
-	}
-
-	results, err := c.dstore.Query(q)
-	if err != nil {
-		return err
-	}
-	defer results.Close()
-
-	for r := range results.Next() {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		if r.Error != nil {
-			return fmt.Errorf("cannot read cache key: %s", r.Error)
-		}
-		if err = c.dstore.Delete(ds.RawKey(r.Entry.Key)); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }

--- a/engine/dscache_test.go
+++ b/engine/dscache_test.go
@@ -1,0 +1,89 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	ds "github.com/ipfs/go-datastore"
+	lds "github.com/ipfs/go-ds-leveldb"
+)
+
+func TestDsCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	ldstore, err := lds.NewDatastore(tmpDir, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cache, err := newDsCache(ctx, ldstore, 5, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := ds.NewKey("hw")
+	val := []byte("hello world")
+
+	// Test Put and Get.
+	err = cache.Put(key, val)
+	if err != nil {
+		t.Fatal(err)
+	}
+	val2, err := cache.Get(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(val2, val) {
+		t.Fatal("wrong value returned")
+	}
+
+	// Test cache eviction.
+	for i := 0; i < cache.Cap(); i++ {
+		k := ds.NewKey(fmt.Sprintf("key-%d", i))
+		err = cache.Put(k, []byte(fmt.Sprintf("val-%d", i)))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if cache.Len() != cache.Cap() {
+		t.Fatalf("expected len to be %d, got %d", cache.Cap(), cache.Len())
+	}
+	_, err = cache.Get(key)
+	if err != ds.ErrNotFound {
+		t.Fatalf("Expected error %s, got %s", ds.ErrNotFound, err)
+	}
+	_, err = cache.dstore.Get(key)
+	if err != ds.ErrNotFound {
+		t.Fatalf("value for %q was not removed from datastore", key)
+	}
+
+	// Test loading cache from datastore.
+	cache, err = newDsCache(ctx, ldstore, 3, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Check that cache was resized.
+	if cache.Cap() != 5 {
+		t.Fatal("cache did not resize to 5")
+	}
+	if cache.Len() != cache.Cap() {
+		t.Fatalf("expected %d items in cache, got %d", cache.Cap(), cache.Len())
+	}
+
+	// Test purge cache
+	cache, err = newDsCache(ctx, ldstore, 3, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cache.Len() != 0 {
+		t.Fatal("cache was not purged")
+	}
+	if cache.Cap() != 3 {
+		t.Fatal("cache has wrong capacity")
+	}
+}

--- a/engine/dscache_test.go
+++ b/engine/dscache_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
+	"runtime"
 	"testing"
 	"time"
 
@@ -12,7 +14,17 @@ import (
 )
 
 func TestDsCache(t *testing.T) {
-	tmpDir := t.TempDir()
+	var tmpDir string
+	var err error
+	if runtime.GOOS == "windows" {
+		tmpDir, err = ioutil.TempDir("", "dscache_test")
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		tmpDir = t.TempDir()
+	}
+
 	ldstore, err := lds.NewDatastore(tmpDir, nil)
 	if err != nil {
 		panic(err)

--- a/engine/dscache_test.go
+++ b/engine/dscache_test.go
@@ -21,7 +21,7 @@ func TestDsCache(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	cache, err := newDsCache(ctx, ldstore, 5, false)
+	cache, err := newDsCache(ctx, ldstore, 5)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestDsCache(t *testing.T) {
 	}
 
 	// Test loading cache from datastore.
-	cache, err = newDsCache(ctx, ldstore, 3, false)
+	cache, err = newDsCache(ctx, ldstore, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,15 +75,17 @@ func TestDsCache(t *testing.T) {
 		t.Fatalf("expected %d items in cache, got %d", cache.Cap(), cache.Len())
 	}
 
-	// Test purge cache
-	cache, err = newDsCache(ctx, ldstore, 3, true)
+	// Test cache Clear.
+	cache.Clear()
+	if cache.Len() != 0 {
+		t.Fatal("cache was not purged")
+	}
+	// Check that no keys are loaded from datastore.
+	cache, err = newDsCache(ctx, ldstore, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if cache.Len() != 0 {
 		t.Fatal("cache was not purged")
-	}
-	if cache.Cap() != 3 {
-		t.Fatal("cache has wrong capacity")
 	}
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -65,9 +65,13 @@ func New(ctx context.Context, ingestCfg config.Ingest, privKey crypto.PrivKey, d
 		log.Infof("Retrieval address not configured, using %s", addrs[0])
 	}
 
-	dsCache, err := newDsCache(ctx, ds, ingestCfg.LinkCacheSize, ingestCfg.PurgeLinkCache)
+	dsCache, err := newDsCache(ctx, ds, ingestCfg.LinkCacheSize)
 	if err != nil {
 		return nil, err
+	}
+
+	if ingestCfg.PurgeLinkCache {
+		dsCache.Clear()
 	}
 
 	if dsCache.Cap() > ingestCfg.LinkCacheSize {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	dt "github.com/filecoin-project/go-data-transfer"
@@ -13,7 +14,6 @@ import (
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
-	dssync "github.com/ipfs/go-datastore/sync"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -24,12 +24,6 @@ import (
 var log = logging.Logger("provider/engine")
 
 var _ provider.Interface = (*Engine)(nil)
-
-// TODO: Consider including this constant as config or options
-// in provider so they are conigurable.
-
-// maxIngestChunk is the maximum number of entries to include in each chunk of ingestion linked list.
-const maxIngestChunk = 100
 
 // Engine is an implementation of the core reference provider interface
 type Engine struct {
@@ -44,42 +38,64 @@ type Engine struct {
 	lsys ipld.LinkSystem
 	// cachelsys is used to track the linked lists through ingestion
 	cachelsys ipld.LinkSystem
-	cache     datastore.Batching
+	cache     datastore.Datastore
 	// ds is the datastore used for persistence of different assets (advertisements,
 	// indexed data, etc.)
-	ds datastore.Batching
-	lp legs.LegPublisher
+	ds        datastore.Batching
+	lp        legs.LegPublisher
+	pubCancel context.CancelFunc
+
 	// pubsubtopic where the provider will push advertisements
-	pubSubTopic string
+	pubSubTopic     string
+	linkedChunkSize int
 
 	// cb is the callback used in the linkSystem
 	cb   provider.Callback
 	cblk sync.Mutex
 }
 
-// New creates a new engine
-func New(ctx context.Context, privKey crypto.PrivKey, dt dt.Manager, h host.Host, ds datastore.Batching, pubSubTopic string, addrs []string) (*Engine, error) {
+// New creates a new engine.  The context is only used for canceling the call
+// to New.
+func New(ctx context.Context, ingestCfg config.Ingest, privKey crypto.PrivKey, dt dt.Manager, h host.Host, ds datastore.Batching, addrs []string) (*Engine, error) {
+	// Replace any zero-values with defaults.
+	ingestCfg.Defaults()
+
 	if len(addrs) == 0 {
 		addrs = []string{h.Addrs()[0].String()}
 		log.Infof("Retrieval address not configured, using %s", addrs[0])
 	}
 
-	var err error
+	dsCache, err := newDsCache(ctx, ds, ingestCfg.LinkCacheSize, ingestCfg.PurgeLinkCache)
+	if err != nil {
+		return nil, err
+	}
+
+	if dsCache.Cap() > ingestCfg.LinkCacheSize {
+		log.Infow("Link cache expanded to hold previously cached links", "new_size", dsCache.Cap())
+	}
+
 	// TODO(security): We should not keep the privkey decoded here.
 	// We should probably unlock it and lock it every time we need it.
 	// Once we start encrypting the key locally.
 	e := &Engine{
-		host:        h,
-		ds:          ds,
-		privKey:     privKey,
-		pubSubTopic: pubSubTopic,
-		cache:       dssync.MutexWrap(datastore.NewMapDatastore()),
-		addrs:       addrs,
+		host:            h,
+		ds:              ds,
+		privKey:         privKey,
+		pubSubTopic:     ingestCfg.PubSubTopic,
+		linkedChunkSize: ingestCfg.LinkedChunkSize,
+
+		cache: dsCache,
+		addrs: addrs,
 	}
 
 	e.cachelsys = e.cacheLinkSystem()
 	e.lsys = e.mkLinkSystem()
-	e.lp, err = legs.NewPublisherFromExisting(ctx, dt, h, pubSubTopic, e.lsys)
+
+	// Create a context that is used to cancel the publisher on shutdown if
+	// closing it takes too long.
+	var pubCtx context.Context
+	pubCtx, e.pubCancel = context.WithCancel(context.Background())
+	e.lp, err = legs.NewPublisherFromExisting(pubCtx, dt, h, e.pubSubTopic, e.lsys)
 	if err != nil {
 		log.Errorf("Error initializing publisher in engine: %s", err)
 		return nil, err
@@ -95,7 +111,7 @@ func NewFromConfig(ctx context.Context, cfg config.Config, dt dt.Manager, host h
 		log.Errorf("Error decoding private key from provider: %s", err)
 		return nil, err
 	}
-	return New(ctx, privKey, dt, host, ds, cfg.Ingest.PubSubTopic, cfg.ProviderServer.RetrievalMultiaddrs)
+	return New(ctx, cfg.Ingest, privKey, dt, host, ds, cfg.ProviderServer.RetrievalMultiaddrs)
 }
 
 // PublishLocal stores the advertisement in the local datastore.
@@ -157,7 +173,23 @@ func (e *Engine) NotifyRemove(ctx context.Context, contextID []byte) (cid.Cid, e
 }
 
 func (e *Engine) Shutdown(ctx context.Context) error {
-	return e.lp.Close()
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			e.pubCancel()
+		case <-done:
+		}
+	}()
+	err := e.lp.Close()
+	if err != nil {
+		err = fmt.Errorf("error closing leg publisher: %w", err)
+	}
+	close(done)
+	if cerr := e.cache.Close(); cerr != nil {
+		log.Errorf("Error closing link cache: %s", cerr)
+	}
+	return err
 }
 
 func (e *Engine) GetAdv(ctx context.Context, c cid.Cid) (schema.Advertisement, error) {
@@ -218,7 +250,7 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metad
 		}
 		// Generate the linked list ipld.Link that is added to the
 		// advertisement and used for ingestion.
-		lnk, err := generateChunks(e.cachelsys, mhIter, maxIngestChunk)
+		lnk, err := e.generateChunks(mhIter)
 		if err != nil {
 			log.Errorf("Error generating link from list of CIDs for contextID (%s): %s", string(contextID), err)
 			return cid.Undef, err

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -398,7 +398,9 @@ func clean(ls legs.LegSubscriber, e *Engine, cncl context.CancelFunc) func() {
 	return func() {
 		cncl()
 		ls.Close()
-		e.Shutdown(context.Background())
+		if err := e.Shutdown(context.Background()); err != nil {
+			panic(err.Error())
+		}
 	}
 }
 

--- a/engine/linksystem.go
+++ b/engine/linksystem.go
@@ -260,18 +260,6 @@ func (e *Engine) vanillaLinkSystem() ipld.LinkSystem {
 	return lsys
 }
 
-// Linksystem used to generate links from a list of cids without
-// persisting anything in the process.
-func noStoreLinkSystem() ipld.LinkSystem {
-	lsys := cidlink.DefaultLinkSystem()
-	lsys.StorageWriteOpener = func(lctx ipld.LinkContext) (io.Writer, ipld.BlockWriteCommitter, error) {
-		return io.Discard, func(lnk ipld.Link) error {
-			return nil
-		}, nil
-	}
-	return lsys
-}
-
 // decodeIPLDNode from a reaed
 // This is used to get the ipld.Node from a set of raw bytes.
 func decodeIPLDNode(r io.Reader) (ipld.Node, error) {

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,11 @@ require (
 	github.com/filecoin-project/go-data-transfer v1.10.1
 	github.com/filecoin-project/go-legs v0.0.0-20211013165050-9ab325b6d2eb
 	github.com/filecoin-project/go-state-types v0.1.0
-	github.com/filecoin-project/storetheindex v0.0.0-20211013202742-5830dcba0cd1
+	github.com/filecoin-project/storetheindex v0.0.0-20211019180831-2704585e5f99
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.7.4
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-datastore v0.4.6
 	github.com/ipfs/go-ds-leveldb v0.4.2

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/filecoin-project/go-state-types v0.1.0
 	github.com/filecoin-project/storetheindex v0.0.0-20211019180831-2704585e5f99
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.7.4
-	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-datastore v0.4.6
 	github.com/ipfs/go-ds-leveldb v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,7 @@ github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
-github.com/filecoin-project/storetheindex v0.0.0-20211013202742-5830dcba0cd1 h1:delmtzZ2feStg0LR12IV6RRpDrCOfilKqbc1a2aGDA8=
-github.com/filecoin-project/storetheindex v0.0.0-20211013202742-5830dcba0cd1/go.mod h1:FZwp20lY5imEG4SZ0ASHVBRRPujBpmdYBPTQdkHkOIQ=
+github.com/filecoin-project/storetheindex v0.0.0-20211019180831-2704585e5f99 h1:qdlA/LrP6UeYFkyXdZzzQaaUNvKXjRIP5j86peIzgvI=
+github.com/filecoin-project/storetheindex v0.0.0-20211019180831-2704585e5f99/go.mod h1:IwKNyPe59SXmss9mKhx2GzkJXTBSmSjl1FiQTwFdsus=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=

--- a/internal/cardatatransfer/cardatatransfer_test.go
+++ b/internal/cardatatransfer/cardatatransfer_test.go
@@ -171,7 +171,8 @@ func TestCarDataTransfer(t *testing.T) {
 			dstBlockstore := bstore.NewBlockstore(dstStore)
 			lsys := storeutil.LinkSystemForBlockstore(dstBlockstore)
 			dstDt := testutil.SetupDataTransferOnHost(t, dstHost, dstStore, lsys)
-			mn.LinkAll()
+			err = mn.LinkAll()
+			require.NoError(t, err)
 
 			var expectedLen int
 			// read blockstore length ahead of time
@@ -194,8 +195,10 @@ func TestCarDataTransfer(t *testing.T) {
 					dstResultChan <- true
 				}
 			})
-			dstDt.RegisterVoucherResultType(&cardatatransfer.DealResponse{})
-			dstDt.RegisterVoucherType(&cardatatransfer.DealProposal{}, nil)
+			err = dstDt.RegisterVoucherResultType(&cardatatransfer.DealResponse{})
+			require.NoError(t, err)
+			err = dstDt.RegisterVoucherType(&cardatatransfer.DealProposal{}, nil)
+			require.NoError(t, err)
 			_, err = dstDt.OpenPullDataChannel(ctx, srcHost.ID(), data.voucher, data.root, data.selector)
 			require.NoError(t, err)
 

--- a/server/provider/libp2p/protocol_test.go
+++ b/server/provider/libp2p/protocol_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/filecoin-project/indexer-reference-provider/config"
 	"github.com/filecoin-project/indexer-reference-provider/engine"
 	"github.com/filecoin-project/indexer-reference-provider/internal/libp2pserver"
 	"github.com/filecoin-project/indexer-reference-provider/internal/utils"
@@ -33,7 +34,10 @@ func mkEngine(t *testing.T, h host.Host, testTopic string) *engine.Engine {
 
 	dt := testutil.SetupDataTransferOnHost(t, h, store, cidlink.DefaultLinkSystem())
 	mhs, _ := utils.RandomMultihashes(10)
-	e, err := engine.New(context.Background(), priv, dt, h, store, testTopic, nil)
+	ingestCfg := config.Ingest{
+		PubSubTopic: testTopic,
+	}
+	e, err := engine.New(context.Background(), ingestCfg, priv, dt, h, store, nil)
 	require.NoError(t, err)
 	e.RegisterCallback(utils.ToCallback(mhs))
 	return e


### PR DESCRIPTION
This PR uses a datastore-backed LRU cache.  Cache keys (link CIDs) are stored in memory, and the values (multihash chunks) are stored in a persistent datastore.  As new links/chunks are added to the cache, older items are removed when the cache is at capacity.  If a single linked list is more than the cache's current capacity, the cache is resized to hold the entire linked list. 

- Cache size is configurable
- Cache automatically expands to hold largest complete linked list
- Cache persisted across restarts

Fixes #37
Fixes #61
