### PR TITLE
Add error check, and remove unneeded error return

### DIFF
--- a/internal/cardatatransfer/cardatatransfer.go
+++ b/internal/cardatatransfer/cardatatransfer.go
@@ -57,7 +57,10 @@ func StartCarDataTransfer(dt datatransfer.Manager, supplier BlockStoreSupplier) 
 	if err != nil {
 		return err
 	}
-	dt.RegisterVoucherResultType(&DealResponse{})
+	err = dt.RegisterVoucherResultType(&DealResponse{})
+	if err != nil {
+		return err
+	}
 	err = dt.RegisterTransportConfigurer(&DealProposal{}, cdt.transportConfigurer)
 	if err != nil {
 		return err
@@ -143,7 +146,6 @@ func (cdt *carDataTransfer) ValidatePull(isRestart bool, _ datatransfer.ChannelI
 }
 
 func (cdt *carDataTransfer) attemptAcceptDeal(providerDealID ProviderDealID, proposal *DealProposal) (DealStatus, error) {
-
 	if proposal.PieceCID == nil {
 		return DealStatusErrored, errors.New("must specific piece CID")
 	}

--- a/internal/cardatatransfer/stores/stores.go
+++ b/internal/cardatatransfer/stores/stores.go
@@ -31,16 +31,16 @@ func NewReadOnlyBlockstores() *ReadOnlyBlockstores {
 	}
 }
 
-func (r *ReadOnlyBlockstores) Track(key string, bs bstore.Blockstore) (bool, error) {
+func (r *ReadOnlyBlockstores) Track(key string, bs bstore.Blockstore) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if _, ok := r.stores[key]; ok {
-		return false, nil
+		return false
 	}
 
 	r.stores[key] = bs
-	return true, nil
+	return true
 }
 
 func (r *ReadOnlyBlockstores) Get(key string) (bstore.Blockstore, error) {

--- a/internal/cardatatransfer/stores/stores_test.go
+++ b/internal/cardatatransfer/stores/stores_test.go
@@ -27,8 +27,7 @@ func TestReadOnlyStoreTracker(t *testing.T) {
 	require.True(t, stores.IsNotFound(err))
 
 	// Add a read-only blockstore
-	ok, err := tracker.Track(k1, rdOnlyBS1)
-	require.NoError(t, err)
+	ok := tracker.Track(k1, rdOnlyBS1)
 	require.True(t, ok)
 
 	// Get the blockstore using its key
@@ -40,8 +39,7 @@ func TestReadOnlyStoreTracker(t *testing.T) {
 	require.Equal(t, len1, lenGot)
 
 	// Call GetOrOpen with a different CAR file
-	ok, err = tracker.Track(k2, rdOnlyBS2)
-	require.NoError(t, err)
+	ok = tracker.Track(k2, rdOnlyBS2)
 	require.True(t, ok)
 
 	// Verify the blockstore is different


### PR DESCRIPTION
The error return from `Track()` is not currently needed, so removed.  Would rather add it back later if needed than make all code check it unnecessarily, when it may neven be necessary.