### PR TITLE
Represent durations in config as golang duration strings, e.g. "30s"

### DIFF
--- a/config/adminserver.go
+++ b/config/adminserver.go
@@ -9,15 +9,15 @@ import (
 
 const (
 	defaultAdminServerAddr = "/ip4/127.0.0.1/tcp/3102"
-	defaultReadTimeout     = 30 * time.Second
-	defaultWriteTimeout    = 30 * time.Second
+	defaultReadTimeout     = Duration(30 * time.Second)
+	defaultWriteTimeout    = Duration(30 * time.Second)
 )
 
 type AdminServer struct {
 	// Admin is the admin API listen address
 	ListenMultiaddr string
-	ReadTimeout     time.Duration
-	WriteTimeout    time.Duration
+	ReadTimeout     Duration
+	WriteTimeout    Duration
 }
 
 func (as *AdminServer) ListenNetAddr() (string, error) {

--- a/config/types.go
+++ b/config/types.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"encoding"
+	"time"
+)
+
+// Duration wraps time.Duration to provide json serialization and deserialization.
+//
+// NOTE: the zero value encodes to an empty string.
+type Duration time.Duration
+
+func (d *Duration) UnmarshalText(text []byte) error {
+	dur, err := time.ParseDuration(string(text))
+	*d = Duration(dur)
+	return err
+}
+
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(time.Duration(d).String()), nil
+}
+
+func (d Duration) String() string {
+	return time.Duration(d).String()
+}
+
+var _ encoding.TextUnmarshaler = (*Duration)(nil)
+var _ encoding.TextMarshaler = (*Duration)(nil)

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/filecoin-project/indexer-reference-provider/config"
-
 	"github.com/filecoin-project/indexer-reference-provider/engine"
 	"github.com/filecoin-project/indexer-reference-provider/internal/suppliers"
 	"github.com/gorilla/mux"
@@ -36,8 +36,8 @@ func New(cfg config.AdminServer, h host.Host, e *engine.Engine, cs *suppliers.Ca
 	r := mux.NewRouter().StrictSlash(true)
 	server := &http.Server{
 		Handler:      r,
-		WriteTimeout: cfg.WriteTimeout,
-		ReadTimeout:  cfg.ReadTimeout,
+		WriteTimeout: time.Duration(cfg.WriteTimeout),
+		ReadTimeout:  time.Duration(cfg.ReadTimeout),
 	}
 	s := &Server{server, l, h, e}
 


### PR DESCRIPTION
Provide config type that encodes durations as golang duration strings instead of nanosecond value.  This makes the config file easier to read and use.