### PR TITLE
Do not create new advertisement for same content

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -8,4 +8,8 @@ var (
 
 	// ErrContextIDNotFound signals that no item is associated to the given context ID.
 	ErrContextIDNotFound = errors.New("context ID not found")
+
+	// ErrAlreadyAdvertised indicates that an advertisement for identical
+	// content was already published.
+	ErrAlreadyAdvertised = errors.New("advertisement already published")
 )

--- a/interface.go
+++ b/interface.go
@@ -45,6 +45,9 @@ type Interface interface {
 	// is protocol dependant.  The metadata must at least specify a protocol
 	// ID, but its data is optional.
 	//
+	// If both the contextID and metadata are the same as a previous call to
+	// NotifyPut, then ErrAlreadyAdvertised is returned.
+	//
 	// This function returns the ID of the advertisement published.
 	NotifyPut(ctx context.Context, contextID []byte, metadata stiapi.Metadata) (cid.Cid, error)
 

--- a/internal/suppliers/car_supplier.go
+++ b/internal/suppliers/car_supplier.go
@@ -49,8 +49,7 @@ func NewCarSupplier(eng provider.Interface, ds datastore.Datastore, opts ...car.
 
 // Put makes the CAR at the given path, and identified by the given ID,
 // suppliable by this supplier. The return CID can then be used via Supply to
-// get an iterator over CIDs that belong to the CAR. When the CAR ID is not
-// known, Put should be used instead.
+// get an iterator over CIDs that belong to the CAR.
 //
 // This function accepts both CARv1 and CARv2 formats.
 func (cs *CarSupplier) Put(ctx context.Context, contextID []byte, path string, metadata stiapi.Metadata) (cid.Cid, error) {

--- a/server/admin/http/importcar_handler.go
+++ b/server/admin/http/importcar_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/filecoin-project/indexer-reference-provider"
 	"github.com/filecoin-project/indexer-reference-provider/internal/suppliers"
 	"github.com/ipfs/go-cid"
 )
@@ -34,6 +35,13 @@ func (h *importCarHandler) handle(w http.ResponseWriter, r *http.Request) {
 
 	// Respond with cause of failure.
 	if err != nil {
+		if err == provider.ErrAlreadyAdvertised {
+			msg := "CAR already advertised"
+			log.Infow(msg, "path", req.Path)
+			errRes := newErrorResponse(msg)
+			respond(w, http.StatusConflict, errRes)
+			return
+		}
 		log.Errorw("failed to put CAR", "err", err, "path", req.Path)
 		errRes := newErrorResponse("failed to supply CAR. %v", err)
 		respond(w, http.StatusInternalServerError, errRes)

--- a/server/admin/http/importcar_handler_test.go
+++ b/server/admin/http/importcar_handler_test.go
@@ -9,13 +9,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/ipfs/go-cid"
-
+	provider "github.com/filecoin-project/indexer-reference-provider"
 	"github.com/filecoin-project/indexer-reference-provider/internal/cardatatransfer"
 	"github.com/filecoin-project/indexer-reference-provider/internal/suppliers"
 	"github.com/filecoin-project/indexer-reference-provider/internal/utils"
 	mock_provider "github.com/filecoin-project/indexer-reference-provider/mock"
 	"github.com/golang/mock/gomock"
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/require"
@@ -113,4 +113,49 @@ func Test_importCarHandlerFail(t *testing.T) {
 	err = json.Unmarshal(respBytes, &resp)
 	require.NoError(t, err)
 	require.Equal(t, "failed to supply CAR. fish", resp.Message)
+}
+
+func Test_importCarAlreadyAdvertised(t *testing.T) {
+	wantKey := []byte("lobster")
+	wantMetadata, err := cardatatransfer.MetadataFromContextID(wantKey)
+	require.NoError(t, err)
+	icReq := &ImportCarReq{
+		Path:     "fish",
+		Key:      wantKey,
+		Metadata: wantMetadata,
+	}
+
+	jsonReq, err := json.Marshal(icReq)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, "/admin/import/car", bytes.NewReader(jsonReq))
+	require.NoError(t, err)
+
+	mc := gomock.NewController(t)
+	mockEng := mock_provider.NewMockInterface(mc)
+	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	cs := suppliers.NewCarSupplier(mockEng, ds)
+
+	subject := importCarHandler{cs}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(subject.handle)
+
+	mockEng.
+		EXPECT().
+		NotifyPut(gomock.Any(), gomock.Eq(wantKey), gomock.Eq(wantMetadata)).
+		Return(cid.Undef, provider.ErrAlreadyAdvertised)
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusConflict, rr.Code)
+
+	respBytes, err := ioutil.ReadAll(rr.Body)
+	require.NoError(t, err)
+
+	var resp ErrorRes
+	err = json.Unmarshal(respBytes, &resp)
+	require.NoError(t, err)
+	require.Equal(t, "CAR already advertised", resp.Message)
 }


### PR DESCRIPTION
When the same content is put into the provider, reuse the existing set of entries instead of regenerating them.  If the contextID and metadata are also identical, then do not generate a new advertisement.

This PR includes an end-to-end test that:
- Tests that reimporting the same car file, with the same contextID and metadata, does not generate new advertisement
- Tests that reimporting the same car file, with the same contextID and different metadata, generates new advertisement that uses the same chain of entries as the first car advertisement.

Fixes #75 