### PR TITLE
Implement admin server endpoint to remove CARs

### DIFF
--- a/server/admin/http/io.go
+++ b/server/admin/http/io.go
@@ -11,12 +11,16 @@ var (
 	_ io.ReaderFrom = (*ErrorRes)(nil)
 	_ io.ReaderFrom = (*ImportCarReq)(nil)
 	_ io.ReaderFrom = (*ImportCarRes)(nil)
+	_ io.ReaderFrom = (*RemoveCarReq)(nil)
+	_ io.ReaderFrom = (*RemoveCarRes)(nil)
 	_ io.ReaderFrom = (*ConnectReq)(nil)
 	_ io.ReaderFrom = (*ConnectRes)(nil)
 
 	_ io.WriterTo = (*ErrorRes)(nil)
 	_ io.WriterTo = (*ImportCarReq)(nil)
 	_ io.WriterTo = (*ImportCarRes)(nil)
+	_ io.WriterTo = (*RemoveCarReq)(nil)
+	_ io.WriterTo = (*RemoveCarRes)(nil)
 	_ io.WriterTo = (*ConnectReq)(nil)
 	_ io.WriterTo = (*ConnectRes)(nil)
 )
@@ -42,6 +46,22 @@ func (er *ImportCarRes) WriteTo(w io.Writer) (int64, error) {
 }
 
 func (er *ImportCarRes) ReadFrom(r io.Reader) (int64, error) {
+	return unmarshalAsJson(r, er)
+}
+
+func (er *RemoveCarReq) WriteTo(w io.Writer) (int64, error) {
+	return marshalToJson(w, er)
+}
+
+func (er *RemoveCarReq) ReadFrom(r io.Reader) (int64, error) {
+	return unmarshalAsJson(r, er)
+}
+
+func (er *RemoveCarRes) WriteTo(w io.Writer) (int64, error) {
+	return marshalToJson(w, er)
+}
+
+func (er *RemoveCarRes) ReadFrom(r io.Reader) (int64, error) {
 	return unmarshalAsJson(r, er)
 }
 

--- a/server/admin/http/models.go
+++ b/server/admin/http/models.go
@@ -39,3 +39,16 @@ type (
 		AdvId cid.Cid `json:"adv_id"`
 	}
 )
+
+type (
+	// RemoveCarReq represents a request for removing a CAR file.
+	RemoveCarReq struct {
+		// The key associated to the CAR.
+		Key []byte `json:"key"`
+	}
+	// RemoveCarRes represents the response to a RemoveCarReq
+	RemoveCarRes struct {
+		// The CID of the advertisement generated as a result of removal.
+		AdvId cid.Cid `json:"adv_id"`
+	}
+)

--- a/server/admin/http/removecar_handler.go
+++ b/server/admin/http/removecar_handler.go
@@ -1,0 +1,55 @@
+package adminserver
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/filecoin-project/indexer-reference-provider/internal/suppliers"
+)
+
+type removeCarHandler struct {
+	cs *suppliers.CarSupplier
+}
+
+func (h *removeCarHandler) handle(w http.ResponseWriter, r *http.Request) {
+	log.Info("Received remove CAR request")
+
+	// Decode request.
+	var req RemoveCarReq
+	if _, err := req.ReadFrom(r.Body); err != nil {
+		log.Errorw("cannot unmarshal request", "err", err)
+		errRes := newErrorResponse("failed to unmarshal request. %v", err)
+		respond(w, http.StatusBadRequest, errRes)
+		return
+	}
+	if len(req.Key) == 0 {
+		errRes := newErrorResponse("key must be specified")
+		respond(w, http.StatusBadRequest, errRes)
+		return
+	}
+
+	// Remove CAR.
+	ctx := context.Background()
+	log.Info("Removing CAR by key", "key", req.Key)
+	advID, err := h.cs.Remove(ctx, req.Key)
+
+	// Respond with cause of failure.
+	if err != nil {
+		if err == suppliers.ErrNotFound {
+			log.Errorw("CAR not found for given context ID", "contextID", req.Key)
+			errRes := newErrorResponse("No CAR file found for the given Key")
+			respond(w, http.StatusNotFound, errRes)
+			return
+		}
+		log.Errorw("failed to remove CAR", "err", err, "key", req.Key)
+		errRes := newErrorResponse("failed to remove CAR. %v", err)
+		respond(w, http.StatusInternalServerError, errRes)
+		return
+	}
+
+	log.Infow("removed CAR successfully", "contextID", req.Key)
+
+	// Respond with successful remove result.
+	resp := &RemoveCarRes{AdvId: advID}
+	respond(w, http.StatusOK, resp)
+}

--- a/server/admin/http/removecar_handler_test.go
+++ b/server/admin/http/removecar_handler_test.go
@@ -1,0 +1,180 @@
+package adminserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/filecoin-project/indexer-reference-provider/internal/cardatatransfer"
+	"github.com/filecoin-project/indexer-reference-provider/internal/suppliers"
+	"github.com/filecoin-project/indexer-reference-provider/internal/utils"
+	mock_provider "github.com/filecoin-project/indexer-reference-provider/mock"
+	"github.com/golang/mock/gomock"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_removeCarHandler(t *testing.T) {
+	wantKey := []byte("lobster")
+	req := requireRemoveCarHttpRequestFromKey(t, wantKey)
+
+	mc := gomock.NewController(t)
+	mockEng := mock_provider.NewMockInterface(mc)
+	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	cs := suppliers.NewCarSupplier(mockEng, ds)
+
+	subject := removeCarHandler{cs}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(subject.handle)
+	wantCid := requireRandomCid(t)
+	requireMockPut(t, mockEng, wantKey, cs)
+
+	mockEng.
+		EXPECT().
+		NotifyRemove(gomock.Any(), gomock.Eq(wantKey)).
+		Return(wantCid, nil)
+
+	handler.ServeHTTP(rr, req)
+
+	respBytes, err := ioutil.ReadAll(rr.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, rr.Code, string(respBytes))
+
+	var resp RemoveCarRes
+	err = json.Unmarshal(respBytes, &resp)
+	require.NoError(t, err)
+	require.Equal(t, wantCid, resp.AdvId)
+}
+
+func Test_removeCarHandlerFail(t *testing.T) {
+	wantKey := []byte("lobster")
+	req := requireRemoveCarHttpRequestFromKey(t, wantKey)
+
+	mc := gomock.NewController(t)
+	mockEng := mock_provider.NewMockInterface(mc)
+	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	cs := suppliers.NewCarSupplier(mockEng, ds)
+
+	subject := removeCarHandler{cs}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(subject.handle)
+	requireMockPut(t, mockEng, wantKey, cs)
+
+	mockEng.
+		EXPECT().
+		NotifyRemove(gomock.Any(), gomock.Eq(wantKey)).
+		Return(cid.Undef, errors.New("fish"))
+
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	respBytes, err := ioutil.ReadAll(rr.Body)
+	require.NoError(t, err)
+
+	var resp ErrorRes
+	err = json.Unmarshal(respBytes, &resp)
+	require.NoError(t, err)
+	require.Equal(t, "failed to remove CAR. fish", resp.Message)
+}
+
+func Test_removeCarHandler_NonExistingCarIsNotFound(t *testing.T) {
+	wantKey := []byte("lobster")
+	req := requireRemoveCarHttpRequestFromKey(t, wantKey)
+
+	mc := gomock.NewController(t)
+	mockEng := mock_provider.NewMockInterface(mc)
+	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	cs := suppliers.NewCarSupplier(mockEng, ds)
+
+	subject := removeCarHandler{cs}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(subject.handle)
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func Test_removeCarHandler_UnspecifiedKeyIsBadRequest(t *testing.T) {
+	req := requireRemoveCarHttpRequestFromKey(t, []byte{})
+
+	mc := gomock.NewController(t)
+	mockEng := mock_provider.NewMockInterface(mc)
+	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	cs := suppliers.NewCarSupplier(mockEng, ds)
+
+	subject := removeCarHandler{cs}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(subject.handle)
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func Test_removeCarHandler_InvalidJsonIsBadRequest(t *testing.T) {
+	req := requireRemoveCarHttpRequest(t, bytes.NewReader([]byte(`{"fish": that was not JSON`)))
+
+	mc := gomock.NewController(t)
+	mockEng := mock_provider.NewMockInterface(mc)
+	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	ds := dssync.MutexWrap(datastore.NewMapDatastore())
+	cs := suppliers.NewCarSupplier(mockEng, ds)
+
+	subject := removeCarHandler{cs}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(subject.handle)
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func requireRemoveCarHttpRequestFromKey(t *testing.T, key []byte) *http.Request {
+	jsonReq, err := json.Marshal(&RemoveCarReq{Key: key})
+	require.NoError(t, err)
+
+	req := requireRemoveCarHttpRequest(t, bytes.NewReader(jsonReq))
+	return req
+}
+
+func requireRemoveCarHttpRequest(t *testing.T, body io.Reader) *http.Request {
+	req, err := http.NewRequest(http.MethodPost, "/admin/remove/car", body)
+	require.NoError(t, err)
+	return req
+}
+
+func requireMockPut(t *testing.T, mockEng *mock_provider.MockInterface, key []byte, cs *suppliers.CarSupplier) {
+	wantMetadata, err := cardatatransfer.MetadataFromContextID(key)
+	require.NoError(t, err)
+	wantCid := requireRandomCid(t)
+
+	mockEng.
+		EXPECT().
+		NotifyPut(gomock.Any(), gomock.Eq(key), wantMetadata).
+		Return(wantCid, nil)
+	_, err = cs.Put(context.Background(), key, "/fish/in/da/sea", wantMetadata)
+	require.NoError(t, err)
+}
+
+func requireRandomCid(t *testing.T) cid.Cid {
+	randCids, err := utils.RandomCids(1)
+	require.NoError(t, err)
+	return randCids[0]
+}

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -51,6 +51,11 @@ func New(cfg config.AdminServer, h host.Host, e *engine.Engine, cs *suppliers.Ca
 		Methods(http.MethodPost).
 		Headers("Content-Type", "application/json")
 
+	rcHandler := &removeCarHandler{cs}
+	r.HandleFunc("/admin/remove/car", rcHandler.handle).
+		Methods(http.MethodPost).
+		Headers("Content-Type", "application/json")
+
 	return s, nil
 }
 


### PR DESCRIPTION
Implement a HTTP edpoint exposed on admin server that accepts context ID
associated to a CAR that is already imported and advertises its removal.

Note the endpoint does not implement removal by path alone. This is
because the CAR supplier only accepts put with explicit context ID. If
context ID can be generated as the hash of path, then that functionality
seem to be better housed on the admin CLI side or re-introduced in CAR
supplier itself then added to the admin server.

At the engine level, making the end to end functionality work depends
on:
 - https://github.com/filecoin-project/storetheindex/pull/104

This commit focuses on the admin server interface only.

Fixes #77