### PR TITLE
Implement `remove car` CLI command

### DIFF
--- a/cmd/provider/flags.go
+++ b/cmd/provider/flags.go
@@ -98,6 +98,12 @@ var importCarFlags = []cli.Flag{
 	keyFlag,
 }
 
+var removeCarFlags = []cli.Flag{
+	adminAPIFlag,
+	optionalCarPathFlag,
+	keyFlag,
+}
+
 var (
 	metadataFlagValue string
 	metadataFlag      = &cli.StringFlag{
@@ -128,6 +134,16 @@ var (
 		Usage:       "Path to the CAR file to import",
 		Destination: &carPathFlagValue,
 		Required:    true,
+	}
+)
+
+var (
+	optionalCarPathFlagValue string
+	optionalCarPathFlag      = &cli.StringFlag{
+		Name:        "input",
+		Aliases:     []string{"i"},
+		Usage:       "The CAR file path.",
+		Destination: &optionalCarPathFlagValue,
 	}
 )
 

--- a/cmd/provider/import.go
+++ b/cmd/provider/import.go
@@ -26,7 +26,7 @@ var ImportCmd = &cli.Command{
 }
 
 var (
-	key             []byte
+	importCarKey    []byte
 	importCarSubCmd = &cli.Command{
 		Name:    "car",
 		Aliases: []string{"c"},
@@ -46,9 +46,9 @@ func beforeImportCar(cctx *cli.Context) error {
 		if err != nil {
 			return errors.New("key is not a valid base64 encoded string")
 		}
-		key = decoded
+		importCarKey = decoded
 	} else {
-		key = sha256.New().Sum([]byte(carPathFlagValue))
+		importCarKey = sha256.New().Sum([]byte(carPathFlagValue))
 	}
 	if cctx.IsSet(metadataFlag.Name) {
 		decoded, err := base64.StdEncoding.DecodeString(metadataFlagValue)
@@ -60,7 +60,7 @@ func beforeImportCar(cctx *cli.Context) error {
 		// if no metadata is set, generate metadata that is compatible for filecoin retrieval base
 		// on the context ID
 		var err error
-		metadata, err = cardatatransfer.MetadataFromContextID(key)
+		metadata, err = cardatatransfer.MetadataFromContextID(importCarKey)
 		if err != nil {
 			return err
 		}
@@ -71,7 +71,7 @@ func beforeImportCar(cctx *cli.Context) error {
 func doImportCar(cctx *cli.Context) error {
 	req := adminserver.ImportCarReq{
 		Path:     carPathFlagValue,
-		Key:      key,
+		Key:      importCarKey,
 		Metadata: metadata,
 	}
 

--- a/cmd/provider/provider.go
+++ b/cmd/provider/provider.go
@@ -48,6 +48,7 @@ func run() int {
 			ConnectCmd,
 			ImportCmd,
 			RegisterCmd,
+			RemoveCmd,
 		},
 	}
 

--- a/cmd/provider/remove.go
+++ b/cmd/provider/remove.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	adminserver "github.com/filecoin-project/indexer-reference-provider/server/admin/http"
+	"github.com/urfave/cli/v2"
+)
+
+var RemoveCmd = &cli.Command{
+	Name:        "remove",
+	Aliases:     []string{"rm"},
+	Usage:       "Removes previously advertised multihashes by the provider.",
+	Subcommands: []*cli.Command{removeCarSubCmd},
+}
+
+var (
+	removeCarKey    []byte
+	removeCarSubCmd = &cli.Command{
+		Name:    "car",
+		Aliases: []string{"c"},
+		Usage:   "Removes the multihashes previously advertised via a CAR file.",
+		Description: `Publishes an advertisement signalling that the provider no longer provides the
+list of multihashes contained a CAR file.
+
+The CAR file must have previously been imported.
+See import command.
+
+The CAR file to remove is identified by either:
+  - the key option, the key by which the CAR file was previously imported, or
+  - the input option, the path to the CAR file that was previously imported.
+
+Specifying both key and input options is not allowed. In the case where the path option is 
+specified, they key is simply calculated as the SHA_256 hash of the given path.`,
+		Flags:  removeCarFlags,
+		Before: beforeRemoveCar,
+		Action: doRemoveCar,
+	}
+)
+
+func beforeRemoveCar(cctx *cli.Context) error {
+	keyFlagSet := cctx.IsSet(keyFlag.Name)
+	carPathFlagSet := cctx.IsSet(carPathFlag.Name)
+
+	if keyFlagSet && carPathFlagSet {
+		return fmt.Errorf("only one of %s or %s must be set", keyFlag.Name, carPathFlag.Name)
+	}
+	if !keyFlagSet && !carPathFlagSet {
+		return fmt.Errorf("either %s or %s must be set", keyFlag.Name, carPathFlag.Name)
+	}
+
+	if keyFlagSet {
+		decoded, err := base64.StdEncoding.DecodeString(keyFlagValue)
+		if err != nil {
+			return errors.New("key is not a valid base64 encoded string")
+		}
+		removeCarKey = decoded
+	} else {
+		removeCarKey = sha256.New().Sum([]byte(carPathFlagValue))
+	}
+	return nil
+}
+
+func doRemoveCar(cctx *cli.Context) error {
+	req := adminserver.RemoveCarReq{
+		Key: removeCarKey,
+	}
+
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	bodyReader := bytes.NewReader(reqBody)
+	httpReq, err := http.NewRequestWithContext(cctx.Context, http.MethodPost, adminAPIFlagValue+"/admin/remove/car", bodyReader)
+	if err != nil {
+		return err
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	cl := &http.Client{}
+	resp, err := cl.Do(httpReq)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		statusText := http.StatusText(resp.StatusCode)
+		var errRes adminserver.ErrorRes
+		if _, err := errRes.ReadFrom(resp.Body); err != nil {
+			return fmt.Errorf(
+				"failed to remove car, server responsed with %s. cannot decode error response: %v",
+				http.StatusText(resp.StatusCode), err)
+		}
+		return fmt.Errorf("%s %s", statusText, errRes.Message)
+	}
+
+	log.Info("Successfully removed car", "key", removeCarKey)
+	var res adminserver.RemoveCarRes
+	if _, err := res.ReadFrom(resp.Body); err != nil {
+		return fmt.Errorf("received OK response from server but cannot decode response body. %v", err)
+	}
+	var b bytes.Buffer
+	b.WriteString("Successfully removed CAR.\n")
+	b.WriteString("\t Advertisement ID: ")
+	b.WriteString(res.AdvId.String())
+	b.WriteString("\n")
+	_, err = cctx.App.Writer.Write(b.Bytes())
+	return err
+}

--- a/cmd/provider/testdata/script/remove-car.txt
+++ b/cmd/provider/testdata/script/remove-car.txt
@@ -1,0 +1,18 @@
+# invalid usage prints USAGE
+! provider remove car
+stderr 'Required flag "listen-admin" not set'
+stdout 'USAGE'
+
+! provider remove car -l fish
+stderr 'either key or input must be set'
+! stdout .
+
+# invalid arguments have expected error message
+! provider remove car -l fish -i lobster -k barreleye
+stderr 'only one of key or input must be set'
+! stdout .
+
+# invald admin server address has expected error
+! provider remove car -l http://localhost:45678 -i lobster
+stderr 'Post "http://localhost:45678/admin/remove/car": dial tcp'
+! stdout .


### PR DESCRIPTION
Implement a CLI command that advertises removal of a list of multihashes
previously advertised via importing a CAR file. The command accepts
either the key or the path by which the CAR was imported in order to
identify which CAR file to remove. For the command to work the CAR file
must have previously been advertised.

Note that an optional CAR path flag is added in this commit, since the
existing flag object is mandatory and used in `import car` sub-command.

Relates to:
 - https://github.com/filecoin-project/indexer-reference-provider/pull/83

Fixes #78