### PR TITLE
Rename `IsFree` metadata field to `VerifiedDeal`

### DIFF
--- a/internal/cardatatransfer/cardatatransfer.go
+++ b/internal/cardatatransfer/cardatatransfer.go
@@ -81,7 +81,7 @@ func MetadataFromContextID(contextID []byte) (stiapi.Metadata, error) {
 	}
 	filecoinV1Metadata := &metadata.FilecoinV1Data{
 		PieceCID:      pieceCid,
-		IsFree:        true,
+		VerifiedDeal:  true,
 		FastRetrieval: true,
 	}
 	dataTransferMetadata, err := filecoinV1Metadata.Encode(metadata.GraphSyncV1)

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -70,8 +70,8 @@ const (
 type FilecoinV1Data struct {
 	// PieceCID identifies the piece this data can be found in
 	PieceCID cid.Cid
-	// Free indicates if the retrieval is free
-	IsFree bool
+	// VerifiedDeal indicates if the deal is verified
+	VerifiedDeal bool
 	// FastRetrieval indicates whether the provider claims there is an unsealed copy
 	FastRetrieval bool
 }
@@ -86,7 +86,7 @@ func init() {
 	ts.Accumulate(schema.SpawnStruct("FilecoinV1Data",
 		[]schema.StructField{
 			schema.SpawnStructField("PieceCID", "Link", false, false),
-			schema.SpawnStructField("IsFree", "Bool", false, false),
+			schema.SpawnStructField("VerifiedDeal", "Bool", false, false),
 			schema.SpawnStructField("FastRetrieval", "Bool", false, false),
 		},
 		schema.SpawnStructRepresentationMap(nil),

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -15,22 +15,22 @@ func TestRoundTripDataTransferFilecoin(t *testing.T) {
 	filecoinV1Datas := []*metadata.FilecoinV1Data{
 		{
 			PieceCID:      cids[0],
-			IsFree:        false,
+			VerifiedDeal:  false,
 			FastRetrieval: false,
 		},
 		{
 			PieceCID:      cids[1],
-			IsFree:        false,
+			VerifiedDeal:  false,
 			FastRetrieval: true,
 		},
 		{
 			PieceCID:      cids[2],
-			IsFree:        true,
+			VerifiedDeal:  true,
 			FastRetrieval: true,
 		},
 		{
 			PieceCID:      cids[3],
-			IsFree:        true,
+			VerifiedDeal:  true,
 			FastRetrieval: true,
 		},
 	}
@@ -54,7 +54,7 @@ func TestFormatDetection(t *testing.T) {
 	cids := testutil.GenerateCids(1)
 	filecoinV1Data := &metadata.FilecoinV1Data{
 		PieceCID:      cids[0],
-		IsFree:        false,
+		VerifiedDeal:  false,
 		FastRetrieval: false,
 	}
 	dataTransferMetadata, err := filecoinV1Data.Encode(metadata.GraphSyncV1)


### PR DESCRIPTION
Rename the `IsFree` field in `FileCoinV1Data` retrieval metadata to
`VerifiedDeal` so that it is consistent with the terminology used in
FileCoin `DealProposal`.

Note that the rename drops `Is` prefix to be consistent with the naming
of `FastRetrieval` field in metadata.

See:
 - https://github.com/filecoin-project/specs-actors/blob/master/actors/builtin/market/deal.go